### PR TITLE
Remove extraneous override of exemption estimate

### DIFF
--- a/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/service/EstimationService.java
+++ b/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/service/EstimationService.java
@@ -933,8 +933,6 @@ public class EstimationService {
 				
 			case PT_OWNER_EXEMPTION:
 				exemption = exemption.add(estimate.getEstimateAmount());
-				exemption = getExemption(exemption);
-				estimate.setEstimateAmount(exemption);	
 				estimate.setCategory(taxHeadCategoryMap.get(estimate.getTaxHeadCode()));
 				break;
 				


### PR DESCRIPTION
Remove the call to getExemption(exemption) and the subsequent estimate.setEstimateAmount(...) in the PT_OWNER_EXEMPTION case. This prevents the accumulated exemption total from being overwritten by an extra adjustment, simplifying the logic and avoiding incorrect exemption values while still setting the tax head category.