### PR TITLE
Support dynamic callback URLs for eSign flow

### DIFF
--- a/core-services/egov-esign/src/main/java/com/cdac/esign/controller/ESignController.java
+++ b/core-services/egov-esign/src/main/java/com/cdac/esign/controller/ESignController.java
@@ -4,10 +4,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.websocket.server.PathParam;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -30,13 +33,14 @@ public class ESignController {
             @RequestParam("file") String fileStoreId, 
             @RequestParam("tenantid") String tenantId,
             // 1. ADDED: New Parameter for Signer Name (Optional)
-            @RequestParam(value = "signerName", required = false) String signerName) {
+            @RequestParam(value = "signerName", required = false) String signerName,
+            @RequestParam(value = "callbackUrl") String callbackUrl) {
 
         logger.info("Received upload request for file: {}, tenant: {}, signer: {}", fileStoreId, tenantId, signerName);
 
         try {
             // 2. UPDATED: Passing the dynamic 'signerName' instead of null
-            RequestXmlForm responseForm = eSignService.processDocumentUpload(fileStoreId, tenantId,signerName);
+            RequestXmlForm responseForm = eSignService.processDocumentUpload(fileStoreId, tenantId,signerName, callbackUrl);
             
             logger.info("Document upload processed successfully for transaction: {}", responseForm.getAspTxnID());
             return ResponseEntity.ok(responseForm);
@@ -48,10 +52,12 @@ public class ESignController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
+    
     @PostMapping("/complete")
     public ResponseEntity<Map<String, String>> completeSigning(
             @RequestParam("eSignResponse") String response,
             @RequestParam("espTxnID") String espTxnID,
+            @RequestParam(value = "callbackUrl", required = false) String callbackUrl,
             HttpServletRequest request) {
 
         logger.info("Received complete signing request for espTxnID: {}", espTxnID);
@@ -67,7 +73,11 @@ public class ESignController {
             body.put("fileUrl", signingResult.get("fileUrl"));
             body.put("fileStoreId", signingResult.get("fileStoreId")); // New field returned
 
-            return ResponseEntity.ok(body);
+            // Redirect to custom callback URL 
+            String finalRedirectUrl = callbackUrl + "/" + signingResult.get("fileStoreId");
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Location", finalRedirectUrl);
+            return new ResponseEntity<>(headers, HttpStatus.FOUND);
 
         } catch (IllegalStateException e) {
             // ... [Existing error handling] ...

--- a/core-services/egov-esign/src/main/java/com/cdac/esign/service/ESignService.java
+++ b/core-services/egov-esign/src/main/java/com/cdac/esign/service/ESignService.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.w3c.dom.NodeList;
 
@@ -64,7 +65,7 @@ public class ESignService {
     /**
      * PHASE 1: Prepare PDF with Dynamic Location & Custom TXN ID
      */
-    public RequestXmlForm processDocumentUpload(String fileStoreId, String tenantId, String signerName) throws Exception {
+    public RequestXmlForm processDocumentUpload(String fileStoreId, String tenantId, String signerName, String callbackUrl) throws Exception {
 
         logger.info("Processing Phase 1 for tenant: {}, signer: {}", tenantId, signerName);
 
@@ -72,6 +73,12 @@ public class ESignService {
             signerName = "Authorized Signatory"; 
         }
 
+        String responseUrl = env.getProperty("esign.response.host") + env.getProperty("esign.response.url");
+        
+        //Added Custome response Url logic
+        if(!StringUtils.isEmpty(callbackUrl))
+        	responseUrl += "?callbackUrl=" + callbackUrl;
+        
         // 1. Get Original PDF
         String pdfUrl = getPdfUrlFromFilestore(fileStoreId, tenantId);
         byte[] originalPdfBytes = downloadPdfFromUrlAsBytes(pdfUrl);
@@ -82,8 +89,8 @@ public class ESignService {
         PdfSigner signer = new PdfSigner(reader, preparedPdfStream, new StampingProperties());
 
         PdfSignatureAppearance appearance = signer.getSignatureAppearance();
-        appearance.setPageRect(new Rectangle(330, 50, 200, 80));
-        appearance.setPageNumber(1);
+        appearance.setPageRect(new Rectangle(340, 50, 200, 80));
+//        appearance.setPageNumber(1);
 
         DateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z");
         dateFormat.setTimeZone(TimeZone.getTimeZone("IST"));
@@ -136,7 +143,7 @@ public class ESignService {
         formXmlDataAsp.setAspId(env.getProperty("esign.asp.id"));
         formXmlDataAsp.setAuthMode(env.getProperty("esign.auth.mode"));
         formXmlDataAsp.setResponseSigType(env.getProperty("esign.response.sig.type"));
-        formXmlDataAsp.setResponseUrl(env.getProperty("esign.response.host") + env.getProperty("esign.response.url"));
+        formXmlDataAsp.setResponseUrl(responseUrl);
         formXmlDataAsp.setId("1");
         formXmlDataAsp.setHashAlgorithm(env.getProperty("esign.hash.algorithm"));
         formXmlDataAsp.setDocInfo(env.getProperty("esign.doc.info"));


### PR DESCRIPTION
Add support for passing a callbackUrl through the eSign endpoints and service. The upload endpoint now accepts callbackUrl and forwards it to ESignService.processDocumentUpload; the service builds the ASP response URL from env properties and appends the provided callbackUrl when present. The complete endpoint now optionally accepts callbackUrl and returns a 302 redirect to callbackUrl/<fileStoreId> instead of returning the response body. Other small changes: updated processDocumentUpload signature, adjusted signature appearance rectangle (removed explicit page number), and added necessary imports (StringUtils, HttpHeaders). These changes enable dynamic client callbacks after signing completes.