### PR TITLE
Esign validity date issue resolved - bpa sanction letter normal workflow

### DIFF
--- a/frontend/micro-ui/web/docker/Dockerfile
+++ b/frontend/micro-ui/web/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN yarn add @mseva/digit-ui-module-swach@1.0.55
 RUN yarn add @mseva/digit-ui-module-pt@1.0.39-dev.1.5
 RUN yarn add @mseva/digit-ui-module-tl@1.0.31-dev.1.7
 RUN yarn add @mseva/digit-ui-module-firenoc@1.0.0-dev.1.3
-RUN yarn add @mseva/digit-ui-module-obps@1.1.89-dev.1.50
+RUN yarn add @mseva/digit-ui-module-obps@1.1.89-dev.1.51
 RUN yarn add @mseva/digit-ui-module-sv@1.1.49-dev.1.13
 RUN yarn add @mseva/upyog-ui-module-ads@1.1.86-dev.2.5
 RUN yarn add @mseva/upyog-ui-module-chb@1.1.91-dev.1.13

--- a/frontend/micro-ui/web/micro-ui-internals/example/devpackage.json
+++ b/frontend/micro-ui/web/micro-ui-internals/example/devpackage.json
@@ -25,7 +25,7 @@
     "@mseva/digit-ui-module-commonpt": "1.0.6",
     "@mseva/digit-ui-module-pt": "1.0.39-dev.1.5",
     "@mseva/digit-ui-module-tl": "1.0.31-dev.1.7",
-    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.50",
+    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.51",
     "@mseva/digit-ui-module-sv": "1.1.49-dev.1.13",
     "@mseva/upyog-ui-module-ads": "1.1.86-dev.2.5",
     "@mseva/upyog-ui-module-chb": "1.1.91-dev.1.13",

--- a/frontend/micro-ui/web/micro-ui-internals/example/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/example/package.json
@@ -26,7 +26,7 @@
     "@mseva/digit-ui-module-swach": "1.0.55",
     "@mseva/digit-ui-module-pt": "1.0.39-dev.1.5",
     "@mseva/digit-ui-module-tl": "1.0.31-dev.1.7",
-    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.50",
+    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.51",
     "@mseva/digit-ui-module-sv": "1.1.49-dev.1.13",
     "@mseva/upyog-ui-module-ads": "1.1.86-dev.2.5",
     "@mseva/upyog-ui-module-chb": "1.1.91-dev.1.13",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/obps/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/obps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mseva/digit-ui-module-obps",
-  "version": "1.1.89-dev.1.50",
+  "version": "1.1.89-dev.1.51",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/Module.js",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/obps/src/pages/employee/BpaApplicationDetails/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/obps/src/pages/employee/BpaApplicationDetails/index.js
@@ -1038,12 +1038,16 @@ const BpaApplicationDetail = () => {
       const nowIST = new Date().toLocaleString('en-GB', { timeZone: 'Asia/Kolkata', hour12: false }).replace(',', '') + ' IST';
       const newValidityDate = Date.now();
   
-      // validity date = approval date + 3 as per feedback
-      newValidityDate.setFullYear(newValidityDate.getFullYear() + 3);
-      const approvalDatePlusThree = newValidityDate.getTime();
+            
+      const validityDateObj = new Date(newValidityDate);
+
+      validityDateObj.setFullYear(validityDateObj.getFullYear() + 3);
+
+      const approvalDatePlusThree = validityDateObj.getTime();
+
   
       const designation = ulbType === "Municipal Corporation" ? "Municipal Commissioner" : "Executive Officer";
-      const requestData = { ...data?.applicationData, edcrDetail: [{ ...data?.edcrDetails }], subjectLine, fileno, nowIST, newValidityDate, designation, approverComment: comments }
+      const requestData = { ...data?.applicationData, edcrDetail: [{ ...data?.edcrDetails }], subjectLine, fileno, nowIST, newValidityDate : approvalDatePlusThree, designation, approverComment: comments }
       let count = 0
       for (let i = 0; i < workflowDetails?.data?.processInstances?.length; i++) {
         if (

--- a/frontend/micro-ui/web/package.json
+++ b/frontend/micro-ui/web/package.json
@@ -59,7 +59,7 @@
     "@mseva/digit-ui-module-ws": "1.0.15",
     "@mseva/digit-ui-module-pt": "1.0.39-dev.1.5",
     "@mseva/digit-ui-module-tl": "1.0.31-dev.1.7",
-    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.50",
+    "@mseva/digit-ui-module-obps": "1.1.89-dev.1.51",
     "@mseva/digit-ui-module-sv": "1.1.49-dev.1.13",
     "@mseva/upyog-ui-module-ads": "1.1.86-dev.2.5",
     "@mseva/upyog-ui-module-chb": "1.1.91-dev.1.13",


### PR DESCRIPTION
For BPA employee application details sanctionletter, the validity date is converted to a date object, extended by three years, and converted back to epoch for the pdf create payload.