### PR TITLE
Add PDF generation and email template enhancements

### DIFF
--- a/core-services/user-otp/src/main/java/org/egov/domain/model/OtpRequest.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/model/OtpRequest.java
@@ -14,6 +14,8 @@ import static org.springframework.util.StringUtils.isEmpty;
 public class OtpRequest {
 	@Setter
     private String mobileNumber;
+	@Setter
+	private String emailId;
     private String tenantId;
     private OtpRequestType type;
     private String userType;
@@ -23,7 +25,8 @@ public class OtpRequest {
 				|| isMobileNumberAbsent()
 				|| isInvalidType()
 				|| isMobileNumberNumeric()
-				|| isMobileNumberValidLength()) {
+				|| isMobileNumberValidLength()
+				|| isEmailValid()) {
             throw new InvalidOtpRequestException(this);
         }
     }
@@ -42,6 +45,17 @@ public class OtpRequest {
 		return false;
 	}
     
+	public boolean isEmailValid() {
+
+	    // Email is optional
+	    if (emailId == null || emailId.trim().isEmpty()) {
+	        return false;
+	    }
+
+	    // return TRUE only when invalid
+	    return !emailId.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+	}
+
 	public boolean isRegistrationRequestType() {
     	return OtpRequestType.REGISTER.equals(getType());
 	}

--- a/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
+++ b/core-services/user-otp/src/main/java/org/egov/domain/service/OtpService.java
@@ -53,8 +53,8 @@ public class OtpService {
         if (!otpRequest.getIsThirdParty())
         { final String otpNumber = otpRepository.fetchOtp(otpRequest);
                 otpSMSSender.send(otpRequest, otpNumber);
-                if (null != matchingUser && null != matchingUser.getEmail())
-                otpEmailRepository.send(matchingUser.getEmail(), otpNumber);
+                if (otpRequest.getEmailId() != null && !otpRequest.getEmailId().isEmpty())
+                otpEmailRepository.send(otpRequest.getEmailId(), otpNumber, otpRequest);
         }
     }
 
@@ -70,7 +70,8 @@ public class OtpService {
             final String otpNumber = otpRepository.fetchOtp(otpRequest);
             otpRequest.setMobileNumber(matchingUser.getMobileNumber());
             otpSMSSender.send(otpRequest, otpNumber);
-            otpEmailRepository.send(matchingUser.getEmail(), otpNumber);
+            if (matchingUser.getEmail() != null && !matchingUser.getEmail().isEmpty())
+            	otpEmailRepository.send(matchingUser.getEmail(), otpNumber, otpRequest);
         } catch (Exception e) {
             log.error("Exception while fetching otp: ", e);
         }

--- a/core-services/user-otp/src/main/java/org/egov/persistence/contract/EmailMessage.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/contract/EmailMessage.java
@@ -14,4 +14,5 @@ public class EmailMessage {
 	private String subject;
 	private String body;
 	private String sender;
+	private	Boolean isHTML;
 }

--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
@@ -1,5 +1,19 @@
 package org.egov.persistence.repository;
 
+import org.egov.domain.model.OtpRequest;
+import org.egov.domain.service.LocalizationService;
+import org.egov.persistence.contract.EmailMessage;
+import org.egov.tracer.kafka.CustomKafkaTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.Stripackage org.egov.persistence.repository;
+
+import org.egov.domain.model.OtpRequest;
+import org.egov.domain.service.LocalizationService;
 import org.egov.persistence.contract.EmailMessage;
 import org.egov.tracer.kafka.CustomKafkaTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,38 +24,172 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.util.Map;
+
 @Service
 public class OtpEmailRepository {
-    private static final String PASSWORD_RESET_SUBJECT = "Password Reset";
+	private static final String PASSWORD_RESET_SUBJECT = "mSeva Punjab - Password Reset Verification";
+	private static final String REGISTER_SUBJECT = "mSeva Punjab - Registration OTP";
+    private static final String LOGIN_SUBJECT = "OTP for Login - mSeva Punjab Municipal Services";
     private static final String PASSWORD_RESET_BODY = "Your OTP for recovering password is %s.";
     private CustomKafkaTemplate<String, EmailMessage> kafkaTemplate;
     private String emailTopic;
-
+    private static final String LOCALIZATION_KEY_REGISTER_MAIL = "email_register_otp";
+    private static final String LOCALIZATION_KEY_LOGIN_MAIL = "email_login_otp";
+    private static final String LOCALIZATION_KEY_PWD_RESET_MAIL = "email_reset_otp";
     @Autowired
     public OtpEmailRepository(CustomKafkaTemplate<String, EmailMessage> kafkaTemplate,
 							  @Value("${email.topic}") String emailTopic) {
         this.kafkaTemplate = kafkaTemplate;
         this.emailTopic = emailTopic;
     }
-
-    public void send(String email, String otpNumber) {
+    @Autowired
+    private LocalizationService localizationService;
+    
+    
+    public void send(String email, String otpNumber, OtpRequest otpRequest) {
     	if (isEmpty(email)) {
 			return;
 		}
-		sendEmail(email, otpNumber);
+		sendEmail(email, otpNumber, otpRequest);
     }
 
-	private void sendEmail(String email, String otpNumber) {
-		final EmailMessage emailMessage = EmailMessage.builder()
-				.body(getBody(otpNumber))
-				.subject(getSubject())
-				.emailTo(email)
-				.sender(EMPTY)
-				.build();
-		kafkaTemplate.send(emailTopic, emailMessage);
+    private void sendEmail(String email, String otpNumber, OtpRequest otpRequest) {
+
+        final String messageFormat = getMessageFormat(otpRequest);
+        String finalBody = messageFormat
+                .replace("{otp}", otpNumber)
+                .replace("{userName}", "Citizen")
+                .replace("{expiryMinutes}", "15")
+                .replace("{cityName}", "Punjab");
+        final EmailMessage emailMessage = EmailMessage.builder()
+                .body(finalBody)
+                .subject(getSubject(otpRequest))
+                .emailTo(email)
+                .isHTML(true)
+                .sender(EMPTY)
+                .build();
+
+        kafkaTemplate.send(emailTopic, emailMessage);
+    }
+
+    private String getMessageFormat(OtpRequest otpRequest) {
+        String tenantId = "pb";
+        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, "en_IN", "egov-user");
+        if (localisedMsgs.isEmpty()) {
+            localisedMsgs.put(LOCALIZATION_KEY_REGISTER_MAIL, "Dear Citizen, Your OTP to complete your mSeva Registration is %s.");
+            localisedMsgs.put(LOCALIZATION_KEY_LOGIN_MAIL, "Dear Citizen, Your Login OTP is %s.");
+            localisedMsgs.put(LOCALIZATION_KEY_PWD_RESET_MAIL, "Dear Citizen, Your OTP for recovering password is %s.");
+        }
+        String message = null;
+
+        if (otpRequest.isRegistrationRequestType())
+            message = localisedMsgs.get(LOCALIZATION_KEY_REGISTER_MAIL);
+        else if (otpRequest.isLoginRequestType())
+            message = localisedMsgs.get(LOCALIZATION_KEY_LOGIN_MAIL);
+        else
+            message = localisedMsgs.get(LOCALIZATION_KEY_PWD_RESET_MAIL);
+
+        return message;
+    }
+    
+	private String getSubject( OtpRequest otpRequest) {
+		if (!isEmpty(otpRequest.getType().toString())) {
+			if (otpRequest.isRegistrationRequestType())
+				return REGISTER_SUBJECT;
+			else if (otpRequest.isLoginRequestType())
+				return LOGIN_SUBJECT;
+			else
+				return PASSWORD_RESET_SUBJECT;
+		}
+		return PASSWORD_RESET_SUBJECT;
 	}
 
-	private String getSubject() {
+	private String getBody(String otpNumber) {
+		return format(PASSWORD_RESET_BODY, otpNumber);
+	}
+
+}
+ngUtils.isEmpty;
+
+import java.util.Map;
+
+@Service
+public class OtpEmailRepository {
+	private static final String PASSWORD_RESET_SUBJECT = "mSeva Punjab - Password Reset Verification";
+	private static final String REGISTER_SUBJECT = "mSeva Punjab - Registration OTP";
+    private static final String LOGIN_SUBJECT = "OTP for Login - mSeva Punjab Municipal Services";
+    private static final String PASSWORD_RESET_BODY = "Your OTP for recovering password is %s.";
+    private CustomKafkaTemplate<String, EmailMessage> kafkaTemplate;
+    private String emailTopic;
+    private static final String LOCALIZATION_KEY_REGISTER_MAIL = "email_register_otp";
+    private static final String LOCALIZATION_KEY_LOGIN_MAIL = "email_login_otp";
+    private static final String LOCALIZATION_KEY_PWD_RESET_MAIL = "email_reset_otp";
+    @Autowired
+    public OtpEmailRepository(CustomKafkaTemplate<String, EmailMessage> kafkaTemplate,
+							  @Value("${email.topic}") String emailTopic) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.emailTopic = emailTopic;
+    }
+    @Autowired
+    private LocalizationService localizationService;
+    
+    
+    public void send(String email, String otpNumber, OtpRequest otpRequest) {
+    	if (isEmpty(email)) {
+			return;
+		}
+		sendEmail(email, otpNumber, otpRequest);
+    }
+
+    private void sendEmail(String email, String otpNumber, OtpRequest otpRequest) {
+
+        final String messageFormat = getMessageFormat(otpRequest);
+        String finalBody = messageFormat
+                .replace("{otp}", otpNumber)
+                .replace("{userName}", "Citizen")
+                .replace("{expiryMinutes}", "15")
+                .replace("{cityName}", "Punjab");
+        final EmailMessage emailMessage = EmailMessage.builder()
+                .body(finalBody)
+                .subject(getSubject(otpRequest))
+                .emailTo(email)
+                .isHTML(true)
+                .sender(EMPTY)
+                .build();
+
+        kafkaTemplate.send(emailTopic, emailMessage);
+    }
+
+    private String getMessageFormat(OtpRequest otpRequest) {
+        String tenantId = "pb";
+        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, "en_IN", "egov-user");
+        if (localisedMsgs.isEmpty()) {
+            localisedMsgs.put(LOCALIZATION_KEY_REGISTER_MAIL, "Dear Citizen, Your OTP to complete your mSeva Registration is %s.");
+            localisedMsgs.put(LOCALIZATION_KEY_LOGIN_MAIL, "Dear Citizen, Your Login OTP is %s.");
+            localisedMsgs.put(LOCALIZATION_KEY_PWD_RESET_MAIL, "Dear Citizen, Your OTP for recovering password is %s.");
+        }
+        String message = null;
+
+        if (otpRequest.isRegistrationRequestType())
+            message = localisedMsgs.get(LOCALIZATION_KEY_REGISTER_MAIL);
+        else if (otpRequest.isLoginRequestType())
+            message = localisedMsgs.get(LOCALIZATION_KEY_LOGIN_MAIL);
+        else
+            message = localisedMsgs.get(LOCALIZATION_KEY_PWD_RESET_MAIL);
+
+        return message;
+    }
+    
+	private String getSubject( OtpRequest otpRequest) {
+		if (!isEmpty(otpRequest.getType().toString())) {
+			if (otpRequest.isRegistrationRequestType())
+				return REGISTER_SUBJECT;
+			else if (otpRequest.isLoginRequestType())
+				return LOGIN_SUBJECT;
+			else
+				return PASSWORD_RESET_SUBJECT;
+		}
 		return PASSWORD_RESET_SUBJECT;
 	}
 

--- a/core-services/user-otp/src/main/java/org/egov/web/contract/Otp.java
+++ b/core-services/user-otp/src/main/java/org/egov/web/contract/Otp.java
@@ -17,6 +17,7 @@ public class Otp {
     private static final String USER_LOGIN = "login";
     private String mobileNumber;
     private String tenantId;
+    private String emailId;
     private String type;
     private String userType;
     private Boolean isThirdParty = false; 

--- a/core-services/user-otp/src/main/java/org/egov/web/contract/OtpRequest.java
+++ b/core-services/user-otp/src/main/java/org/egov/web/contract/OtpRequest.java
@@ -15,6 +15,7 @@ public class OtpRequest {
     public org.egov.domain.model.OtpRequest toDomain() {
         return org.egov.domain.model.OtpRequest.builder()
                 .mobileNumber(getMobileNumber())
+                .emailId(otp != null ? otp.getEmailId() : null)
                 .tenantId(getTenantId())
                 .type(getType())
                 .userType(getUserType())


### PR DESCRIPTION
Integrate internal PDF and filestore services to generate trade license PDFs and embed public download links into approval emails. Adds new configuration properties (egov.pdf.internal.host, egov.pdf.internal.create.endpoint, egov.filestore.internal.host, egov.filestore.internal.endpoint.search) and updates application.properties (also fixes kafka email topic name).

Other changes:
- TLNotificationService: null-safe property source handling, new flow to call PDF service, fetch filestore public URL, replace {downloadLink} in messages, logging, error handling and UI fallback; added createPdfRequest helper and @SuppressWarnings.
- NotificationUtil: more robust createEmailRequest with safer subject/body extraction, defaults and error handling.
- TLRenewalNotificationUtil: new getEmailCustomizedMsgMail and getReplacedMailMessage to build approved-license email content (validTo formatting, property/trade/owner extraction, portal link replacement).
- TLConstants: added NOTIF_TRADE_APPROVED_EMAIL and included it in the notification list.

These changes enable automated certificate generation for approved licenses and more resilient email construction.