### PR TITLE
Update OTP email API and adjust tests

### DIFF
--- a/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
+++ b/core-services/user-otp/src/main/java/org/egov/persistence/repository/OtpEmailRepository.java
@@ -10,18 +10,6 @@ import org.springframework.stereotype.Service;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.Stripackage org.egov.persistence.repository;
-
-import org.egov.domain.model.OtpRequest;
-import org.egov.domain.service.LocalizationService;
-import org.egov.persistence.contract.EmailMessage;
-import org.egov.tracer.kafka.CustomKafkaTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Map;
@@ -37,100 +25,15 @@ public class OtpEmailRepository {
     private static final String LOCALIZATION_KEY_REGISTER_MAIL = "email_register_otp";
     private static final String LOCALIZATION_KEY_LOGIN_MAIL = "email_login_otp";
     private static final String LOCALIZATION_KEY_PWD_RESET_MAIL = "email_reset_otp";
+   
+    
     @Autowired
     public OtpEmailRepository(CustomKafkaTemplate<String, EmailMessage> kafkaTemplate,
 							  @Value("${email.topic}") String emailTopic) {
         this.kafkaTemplate = kafkaTemplate;
         this.emailTopic = emailTopic;
     }
-    @Autowired
-    private LocalizationService localizationService;
     
-    
-    public void send(String email, String otpNumber, OtpRequest otpRequest) {
-    	if (isEmpty(email)) {
-			return;
-		}
-		sendEmail(email, otpNumber, otpRequest);
-    }
-
-    private void sendEmail(String email, String otpNumber, OtpRequest otpRequest) {
-
-        final String messageFormat = getMessageFormat(otpRequest);
-        String finalBody = messageFormat
-                .replace("{otp}", otpNumber)
-                .replace("{userName}", "Citizen")
-                .replace("{expiryMinutes}", "15")
-                .replace("{cityName}", "Punjab");
-        final EmailMessage emailMessage = EmailMessage.builder()
-                .body(finalBody)
-                .subject(getSubject(otpRequest))
-                .emailTo(email)
-                .isHTML(true)
-                .sender(EMPTY)
-                .build();
-
-        kafkaTemplate.send(emailTopic, emailMessage);
-    }
-
-    private String getMessageFormat(OtpRequest otpRequest) {
-        String tenantId = "pb";
-        Map<String, String> localisedMsgs = localizationService.getLocalisedMessages(tenantId, "en_IN", "egov-user");
-        if (localisedMsgs.isEmpty()) {
-            localisedMsgs.put(LOCALIZATION_KEY_REGISTER_MAIL, "Dear Citizen, Your OTP to complete your mSeva Registration is %s.");
-            localisedMsgs.put(LOCALIZATION_KEY_LOGIN_MAIL, "Dear Citizen, Your Login OTP is %s.");
-            localisedMsgs.put(LOCALIZATION_KEY_PWD_RESET_MAIL, "Dear Citizen, Your OTP for recovering password is %s.");
-        }
-        String message = null;
-
-        if (otpRequest.isRegistrationRequestType())
-            message = localisedMsgs.get(LOCALIZATION_KEY_REGISTER_MAIL);
-        else if (otpRequest.isLoginRequestType())
-            message = localisedMsgs.get(LOCALIZATION_KEY_LOGIN_MAIL);
-        else
-            message = localisedMsgs.get(LOCALIZATION_KEY_PWD_RESET_MAIL);
-
-        return message;
-    }
-    
-	private String getSubject( OtpRequest otpRequest) {
-		if (!isEmpty(otpRequest.getType().toString())) {
-			if (otpRequest.isRegistrationRequestType())
-				return REGISTER_SUBJECT;
-			else if (otpRequest.isLoginRequestType())
-				return LOGIN_SUBJECT;
-			else
-				return PASSWORD_RESET_SUBJECT;
-		}
-		return PASSWORD_RESET_SUBJECT;
-	}
-
-	private String getBody(String otpNumber) {
-		return format(PASSWORD_RESET_BODY, otpNumber);
-	}
-
-}
-ngUtils.isEmpty;
-
-import java.util.Map;
-
-@Service
-public class OtpEmailRepository {
-	private static final String PASSWORD_RESET_SUBJECT = "mSeva Punjab - Password Reset Verification";
-	private static final String REGISTER_SUBJECT = "mSeva Punjab - Registration OTP";
-    private static final String LOGIN_SUBJECT = "OTP for Login - mSeva Punjab Municipal Services";
-    private static final String PASSWORD_RESET_BODY = "Your OTP for recovering password is %s.";
-    private CustomKafkaTemplate<String, EmailMessage> kafkaTemplate;
-    private String emailTopic;
-    private static final String LOCALIZATION_KEY_REGISTER_MAIL = "email_register_otp";
-    private static final String LOCALIZATION_KEY_LOGIN_MAIL = "email_login_otp";
-    private static final String LOCALIZATION_KEY_PWD_RESET_MAIL = "email_reset_otp";
-    @Autowired
-    public OtpEmailRepository(CustomKafkaTemplate<String, EmailMessage> kafkaTemplate,
-							  @Value("${email.topic}") String emailTopic) {
-        this.kafkaTemplate = kafkaTemplate;
-        this.emailTopic = emailTopic;
-    }
     @Autowired
     private LocalizationService localizationService;
     

--- a/core-services/user-otp/src/test/java/org/egov/domain/service/OtpServiceTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/domain/service/OtpServiceTest.java
@@ -144,6 +144,6 @@ public class OtpServiceTest {
 
 		otpService.sendOtp(otpRequest);
 
-		verify(otpEmailRepository).send("foo@bar.com", otpNumber);
+		verify(otpEmailRepository).send("foo@bar.com", otpNumber, otpRequest);
 	}
 }

--- a/core-services/user-otp/src/test/java/org/egov/persistence/repository/OtpEmailRepositoryTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/persistence/repository/OtpEmailRepositoryTest.java
@@ -9,8 +9,16 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import java.util.HashMap;
+import org.egov.domain.model.OtpRequest;
+import org.egov.domain.service.LocalizationService;
+import org.egov.domain.model.OtpRequestType;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OtpEmailRepositoryTest {
@@ -18,30 +26,40 @@ public class OtpEmailRepositoryTest {
 	private static final String EMAIL_TOPIC = "email.topic";
 	@Mock
 	private CustomKafkaTemplate<String, EmailMessage> kakfaTemplate;
+	@Mock
+	private LocalizationService localizationService;
 	private OtpEmailRepository repository;
 
 	@Before
 	public void before() {
 		repository = new OtpEmailRepository(kakfaTemplate, EMAIL_TOPIC);
+		ReflectionTestUtils.setField(repository, "localizationService", localizationService);
 	}
 
 	@Test
 	public void test_should_not_send_email_when_email_address_is_not_present() {
-		repository.send(null, "otpNumber");
+		repository.send(null, "otpNumber", null);
 
 		verify(kakfaTemplate, never()).send(any(), any());
 	}
 
 	@Test
 	public void test_should_send_email_message() {
+		when(localizationService.getLocalisedMessages(anyString(), anyString(), anyString())).thenReturn(new HashMap<>());
+		OtpRequest otpRequest = mock(OtpRequest.class);
+		when(otpRequest.getType()).thenReturn(OtpRequestType.PASSWORD_RESET);
+		when(otpRequest.isRegistrationRequestType()).thenReturn(false);
+		when(otpRequest.isLoginRequestType()).thenReturn(false);
+
 		final EmailMessage expectedEmailMessage = EmailMessage.builder()
-				.subject("Password Reset")
-				.body("Your OTP for recovering password is otpNumber.")
+				.subject("mSeva Punjab - Password Reset Verification")
+				.body("Dear Citizen, Your OTP for recovering password is %s.")
 				.sender("")
 				.emailTo("foo@bar.com")
+				.isHTML(true)
 				.build();
 
-		repository.send("foo@bar.com", "otpNumber");
+		repository.send("foo@bar.com", "otpNumber", otpRequest);
 
 		verify(kakfaTemplate).send(EMAIL_TOPIC, expectedEmailMessage);
 	}

--- a/core-services/user-otp/src/test/java/org/egov/web/contract/OtpRequestTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/web/contract/OtpRequestTest.java
@@ -11,7 +11,7 @@ public class OtpRequestTest {
 
     @Test
     public void test_should_map_from_contract_to_domain() {
-        final Otp otp = new Otp("mobileNumber", "tenantId", "register", "CITIZEN",false);
+        final Otp otp = new Otp("mobileNumber", "tenantId", null, "register", "CITIZEN",false);
         final OtpRequest request = new OtpRequest(null, otp);
 
         final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -24,7 +24,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_register_when_type_not_explicitly_specified() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", null, "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, null, "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -34,7 +34,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_null_when_type_is_unknown() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "unknown", "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "unknown", "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -44,7 +44,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_register_when_type_is_register() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "regisTER", "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "regisTER", "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -54,7 +54,7 @@ public class OtpRequestTest {
 
 	@Test
 	public void test_should_set_request_type_to_password_reset_when_type_is_passwordreset() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "passwordRESET", "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "passwordRESET", "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -64,7 +64,7 @@ public class OtpRequestTest {
 	
 	@Test
 	public void test_should_set_request_type_login_when_type_is_login() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "LOGIN", "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "LOGIN", "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();
@@ -74,7 +74,7 @@ public class OtpRequestTest {
 	
 	@Test
 	public void test_should_set_request_type_to_login_when_type_is_login() {
-		final Otp otp = new Otp("mobileNumber", "tenantId", "login", "CITIZEN",false);
+		final Otp otp = new Otp("mobileNumber", "tenantId", null, "login", "CITIZEN",false);
 		final OtpRequest request = new OtpRequest(null, otp);
 
 		final org.egov.domain.model.OtpRequest domainOtpRequest = request.toDomain();

--- a/core-services/user-otp/src/test/java/org/egov/web/controller/OtpControllerTest.java
+++ b/core-services/user-otp/src/test/java/org/egov/web/controller/OtpControllerTest.java
@@ -45,13 +45,13 @@ public class OtpControllerTest {
 				.content(resources.getFileContents("otpSendRequest.json"))).andExpect(status().isCreated())
 				.andExpect(content().json(resources.getFileContents("otpSendSuccessResponse.json")));
 
-		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", "tenantId", OtpRequestType.PASSWORD_RESET, "CITIZEN", false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", null, "tenantId", OtpRequestType.PASSWORD_RESET, "CITIZEN", false);
 		verify(otpService).sendOtp(expectedOtpRequest);
 	}
 
 	@Test
 	public void test_should_return_error_response_when_mandatory_fields_are_not_present_in_request() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("", "", null, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("", null, "", null, "CITIZEN",false);
 		doThrow(new InvalidOtpRequestException(expectedOtpRequest)).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -63,7 +63,7 @@ public class OtpControllerTest {
 	@Test
 	public void test_should_return_error_response_when_user_not_found_for_sending_forgot_password_otp()
 			throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("", "", null, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("", null, "", null, "CITIZEN",false);
 		doThrow(new UserNotFoundException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -74,7 +74,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_response_when_user_alreadyExist_incaseoftypeisregister() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", "tenantId", OtpRequestType.REGISTER, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", null, "tenantId", OtpRequestType.REGISTER, "CITIZEN",false);
 		doThrow(new UserAlreadyExistInSystemException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -84,7 +84,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_response_when_user_doesntExist_incaseoftypeislogin() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", "tenantId", OtpRequestType.LOGIN, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", null, "tenantId", OtpRequestType.LOGIN, "CITIZEN",false);
 		doThrow(new UserNotExistingInSystemException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -95,7 +95,7 @@ public class OtpControllerTest {
 	@Test
 	public void test_should_return_error_response_when_user_mobilenot_found_for_sending_forgot_password_otp()
 			throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("", "", null, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("", null, "", null, "CITIZEN",false);
 		doThrow(new UserMobileNumberNotFoundException()).when(otpService).sendOtp(expectedOtpRequest);
 
 		mockMvc.perform(post("/v1/_send").contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -106,7 +106,7 @@ public class OtpControllerTest {
 
 	@Test
 	public void test_should_return_error_message_when_unhandled_exception_occurs() throws Exception {
-		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", "tenantId", null, "CITIZEN",false);
+		final OtpRequest expectedOtpRequest = new OtpRequest("mobileNumber", null, "tenantId", null, "CITIZEN",false);
 		final String exceptionMessage = "Some exception message";
 		doThrow(new RuntimeException(exceptionMessage)).when(otpService).sendOtp(expectedOtpRequest);
 


### PR DESCRIPTION
Refactor OtpEmailRepository: cleaned up imports/duplication and changed send(...) to accept the OtpRequest so localization and request-type-specific subjects/bodies can be used. Updated tests to match the new method and constructor signatures: OtpServiceTest, OtpEmailRepositoryTest (injects mocked LocalizationService and verifies message content/flags), OtpRequestTest and OtpControllerTest (adjusted Otp/OtpRequest constructor argument ordering and expectations). Mock behavior for localization and OTP request types added in repository tests.