### PR TITLE
Support inline email attachments and filestore/pdf

### DIFF
--- a/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/consumer/contract/Email.java
+++ b/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/consumer/contract/Email.java
@@ -27,5 +27,8 @@ public class Email {
 	
 	@JsonProperty("attachments")
     private List<String> attachments;
+	
+	@JsonProperty("inlineAttachments")
+    private List<EmailAttachment> inlineAttachments;
 
 }

--- a/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/consumer/contract/EmailAttachment.java
+++ b/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/consumer/contract/EmailAttachment.java
@@ -1,0 +1,16 @@
+package org.egov.web.notification.mail.consumer.contract;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EmailAttachment {
+    private String url;
+    private String contentId;
+    private String mimeType;
+}

--- a/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/service/ExternalEmailService.java
+++ b/core-services/egov-notification-mail/src/main/java/org/egov/web/notification/mail/service/ExternalEmailService.java
@@ -7,12 +7,14 @@ import java.util.List;
 import javax.mail.internet.MimeMessage;
 
 import org.egov.web.notification.mail.consumer.contract.Email;
+import org.egov.web.notification.mail.consumer.contract.EmailAttachment;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StreamUtils;
@@ -34,6 +36,7 @@ public class ExternalEmailService implements EmailService {
     }
 
     @Override
+    @Async // CRITICAL FIX: Runs email sending in a background thread to prevent Kafka bottlenecks
     public void sendEmail(Email email) {
         try {
             if (email.isHTML()) {
@@ -60,7 +63,6 @@ public class ExternalEmailService implements EmailService {
     private void sendHTMLEmail(Email email) {
         MimeMessage message = mailSender.createMimeMessage();
         try {
-            // true flag indicates multipart message for attachments
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
             
             helper.setFrom(mailSender.getUsername());
@@ -68,8 +70,14 @@ public class ExternalEmailService implements EmailService {
             helper.setSubject(email.getSubject());
             helper.setText(email.getBody(), true);
 
+            // 1. Process NEW Inline Images (For eChallan)
+            if (!CollectionUtils.isEmpty(email.getInlineAttachments())) {
+                processInlineAttachments(email.getInlineAttachments(), helper);
+            }
+
+            // 2. Process LEGACY String Attachments (For PT, TL, WS, etc.)
             if (!CollectionUtils.isEmpty(email.getAttachments())) {
-                processAttachments(email.getAttachments(), helper);
+                processLegacyAttachments(email.getAttachments(), helper);
             }
 
             log.info("Handing over to SMTP Server ({}) for delivery...", mailSender.getHost());
@@ -81,37 +89,64 @@ public class ExternalEmailService implements EmailService {
         }
     }
 
-    private void processAttachments(List<String> attachments, MimeMessageHelper helper) {
-        for (String urlString : attachments) {
+ // --- FOR ECHALLAN (NEW) ---
+    private void processInlineAttachments(List<EmailAttachment> attachments, MimeMessageHelper helper) {
+        for (EmailAttachment attachment : attachments) {
             try {
-                String downloadUrl = urlString;
-
-                // Use the internal routing logic to bypass SSL issues on the server
-                // We check for the filestore path specifically
-                if (urlString.contains("/filestore/v1/files/viewfile")) {
-                    downloadUrl = urlString.replaceFirst("https?://[^/]+", internalHost);
-                    log.info("Rerouting attachment download: {} -> {}", urlString, downloadUrl);
+                String downloadUrl = attachment.getUrl();
+                
+                // Keep routing bypass if testing locally!
+                if (downloadUrl.contains("/filestore/v1/files/viewfile")) {
+                    downloadUrl = downloadUrl.replaceFirst("https?://[^/]+", internalHost);
                 }
 
                 java.net.URL url = new java.net.URL(downloadUrl);
                 java.net.URLConnection conn = url.openConnection();
-                conn.setConnectTimeout(5000);
-                conn.setReadTimeout(10000);
+                conn.setConnectTimeout(3000);
+                conn.setReadTimeout(7000);
 
-                // Download bytes to memory
                 byte[] bytes = org.springframework.util.StreamUtils.copyToByteArray(conn.getInputStream());
 
                 if (bytes != null && bytes.length > 0) {
-                    // Use YOUR extractFileName method here
-                    String fileName = extractFileName(urlString);
+                    org.springframework.core.io.ByteArrayResource resource = new org.springframework.core.io.ByteArrayResource(bytes);
                     
-                    // Attach the unique file
-                    helper.addAttachment(fileName, new org.springframework.core.io.ByteArrayResource(bytes));
-                    log.info("Successfully attached file: {} (Size: {} bytes)", fileName, bytes.length);
+                    if (attachment.getContentId() != null && !attachment.getContentId().isEmpty()) {
+                        helper.addInline(attachment.getContentId(), resource, attachment.getMimeType());
+                        log.info("Attached INLINE image: cid:{}", attachment.getContentId());
+                    } else {
+                        helper.addAttachment("document.pdf", resource);
+                    }
                 }
             } catch (Exception e) {
-                log.error("Failed to process attachment for URL: " + urlString, e);
-                // We continue the loop so other attachments/email can still proceed
+                log.error("Failed to process inline attachment: " + attachment.getUrl(), e);
+            }
+        }
+    }
+
+    // --- FOR OTHER MICROSERVICES (LEGACY) ---
+    private void processLegacyAttachments(List<String> attachments, MimeMessageHelper helper) {
+        for (String urlString : attachments) {
+            try {
+                String downloadUrl = urlString;
+                
+                if (urlString.contains("/filestore/v1/files/viewfile")) {
+                    downloadUrl = urlString.replaceFirst("https?://[^/]+", internalHost);
+                }
+
+                java.net.URL url = new java.net.URL(downloadUrl);
+                java.net.URLConnection conn = url.openConnection();
+                conn.setConnectTimeout(3000);
+                conn.setReadTimeout(7000);
+
+                byte[] bytes = org.springframework.util.StreamUtils.copyToByteArray(conn.getInputStream());
+
+                if (bytes != null && bytes.length > 0) {
+                    String fileName = extractFileName(urlString);
+                    helper.addAttachment(fileName, new org.springframework.core.io.ByteArrayResource(bytes));
+                    log.info("Attached LEGACY file: {}", fileName);
+                }
+            } catch (Exception e) {
+                log.error("Failed to process legacy attachment: " + urlString, e);
             }
         }
     }

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/config/ChallanConfiguration.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/config/ChallanConfiguration.java
@@ -58,7 +58,18 @@ public class ChallanConfiguration {
 
     @Value("${egov.user.username.prefix}")
     private String usernamePrefix;
+    
+    @Value("${egov.pdf.service.host}")
+    private String pdfServiceHost;
 
+    @Value("${egov.pdf.service.create.endpoint}")
+    private String pdfServiceCreateEndpoint;
+    
+    @Value("${egov.filestore.host}")
+    private String fileStoreHost;
+
+    @Value("${egov.filestore.view.endpoint}")
+    private String fileStoreViewPath;
 
     //Idgen Config
     @Value("${egov.idgen.host}")

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/model/Email.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/model/Email.java
@@ -3,6 +3,7 @@ package org.egov.echallan.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
 
 @Setter
@@ -18,5 +19,4 @@ public class Email {
 	private String body;
 	@JsonProperty("isHTML")
 	private boolean isHTML;
-
-}
+	private List<EmailAttachment> inlineAttachments;}

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/model/EmailAttachment.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/model/EmailAttachment.java
@@ -1,0 +1,14 @@
+package org.egov.echallan.model;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailAttachment {
+    private String url;         // The Dev/Public URL to download the image
+    private String contentId;   // This MUST match the cid: tag in HTML (e.g., "evidence1")
+    private String mimeType;    // e.g., "image/jpeg"
+}

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/repository/ServiceRequestRepository.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/repository/ServiceRequestRepository.java
@@ -28,7 +28,7 @@ public class ServiceRequestRepository {
 		Object response = null;
 		log.info("URI: "+uri.toString());
 		try {
-			log.info("Request: "+mapper.writeValueAsString(request));
+//			log.info("Request: "+mapper.writeValueAsString(request));
 			response = restTemplate.postForObject(uri.toString(), request, Map.class);
 		}catch(HttpClientErrorException e) {
 			log.error("External Service threw an Exception: ",e);

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/service/NotificationService.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/service/NotificationService.java
@@ -19,6 +19,7 @@ import org.egov.echallan.web.models.uservevents.Event;
 import org.egov.echallan.web.models.uservevents.EventRequest;
 import org.egov.echallan.web.models.uservevents.Recepient;
 import org.egov.echallan.web.models.uservevents.Source;
+import org.egov.echallan.web.models.workflow.Workflow;
 import org.egov.mdms.model.MasterDetail;
 import org.egov.mdms.model.MdmsCriteria;
 import org.egov.mdms.model.MdmsCriteriaReq;
@@ -109,15 +110,15 @@ public class NotificationService {
 		 * config.getIsUserEventEnabled()) { if (config.getIsUserEventEnabled()) {
 		 * EventRequest eventRequest = getEventsForChallan(challanRequest,isSave);
 		 * if(null != eventRequest) util.sendEventNotification(eventRequest); } } }
-		 * 
-		 * if(configuredChannelNames.contains(CHANNEL_NAME_EMAIL)){ List<EmailRequest>
-		 * emailRequests = new LinkedList<>(); if (null !=
-		 * config.getIsEmailNotificationEnabled()) { if
-		 * (config.getIsEmailNotificationEnabled()) { enrichEmailRequest(challanRequest,
-		 * emailRequests, code.replace(".sms",".email")); if
-		 * (!CollectionUtils.isEmpty(emailRequests)) util.sendEmail(emailRequests); } }
-		 * }
 		 */
+		 if(configuredChannelNames.contains(CHANNEL_NAME_EMAIL)){ List<EmailRequest>
+		  emailRequests = new LinkedList<>(); if (null !=
+		  config.getIsEmailNotificationEnabled()) { if
+		  (config.getIsEmailNotificationEnabled()) { enrichEmailRequest(challanRequest,
+		  emailRequests, code.replace(".sms",".email")); if
+		  (!CollectionUtils.isEmpty(emailRequests)) util.sendEmail(emailRequests); } }
+		  }
+		 
 	}
 
 	private EventRequest getEventsForChallan(ChallanRequest request,boolean isSave) {
@@ -272,36 +273,119 @@ public class NotificationService {
 		 * @param code
 		 *            Notification Template Code
 		 */
-		private void enrichEmailRequest(ChallanRequest challanRequest, List<EmailRequest> emailRequestList, String code) {
-			Set<String> mobileNumbers = new HashSet<>();
-			String mobilenumber = challanRequest.getChallan().getCitizen().getMobileNumber();
+	private void enrichEmailRequest(ChallanRequest challanRequest, List<EmailRequest> emailRequestList, String code) {
+	    Set<String> mobileNumbers = new HashSet<>();
+	    String mobilenumber = challanRequest.getChallan().getCitizen().getMobileNumber();
 
-			mobileNumbers.add(mobilenumber);
-			Map<String, String> mapOfPhnoAndEmail = util.fetchUserEmailIds(mobileNumbers, challanRequest.getRequestInfo(), challanRequest.getChallan().getTenantId());
+	    mobileNumbers.add(mobilenumber);
+	    Map<String, String> mapOfPhnoAndEmail = util.fetchUserEmailIds(mobileNumbers, challanRequest.getRequestInfo(), challanRequest.getChallan().getTenantId());
 
-			if(challanRequest.getChallan().getCitizen().getEmail()!=null && !StringUtils.isEmpty(challanRequest.getChallan().getCitizen().getEmail()) )
-				mapOfPhnoAndEmail.put(mobilenumber, challanRequest.getChallan().getCitizen().getEmail());
+	    if (challanRequest.getChallan().getCitizen().getEmail() != null && !StringUtils.isEmpty(challanRequest.getChallan().getCitizen().getEmail())) {
+	        mapOfPhnoAndEmail.put(mobilenumber, challanRequest.getChallan().getCitizen().getEmail());
+	    }
 
-			String message = util.getEmailCustomizedMsg(challanRequest.getRequestInfo(), challanRequest.getChallan(), code);
+	    String message = util.getEmailCustomizedMsg(challanRequest.getRequestInfo(), challanRequest.getChallan(), code);
 
-			if (message!=null && !StringUtils.isEmpty(message)) {
-				String subject = message.substring(message.indexOf("<h2>")+4,message.indexOf("</h2>"));
-				String body = message.substring(message.indexOf("</h2>")+5);
-				Email emailobj=null;
-				EmailRequest email = null;
-				if(mapOfPhnoAndEmail.get(mobilenumber)!=null) {
-					emailobj = Email.builder().emailTo(Collections.singleton(mapOfPhnoAndEmail.get(mobilenumber))).isHTML(true).body(body).subject(subject).build();
-					email = new EmailRequest(challanRequest.getRequestInfo(),emailobj);
-					emailRequestList.add(email);
-				}
-				else
-				{
-					log.error("No email for username - "+mobilenumber);
-				}
-			} else {
-				log.error("No message configured! Notification will not be sent.");
-			}
+	 // Inside your enrichEmailRequest method...
+
+	    if (message != null && !StringUtils.isEmpty(message)) {
+	        String subject = getSubjectBasedOnWorkflow(challanRequest.getChallan(), challanRequest.getChallan().getWorkflow());
+	        String body = message;
+
+	        // ==========================================
+	        // NEW LOGIC: Map the Filestore URLs to the cid tags
+	        // ==========================================
+	        List<EmailAttachment> attachments = new ArrayList<>();
+	        
+	        if (challanRequest.getChallan().getUploadedDocumentDetails() != null) {
+	            for (DocumentDetail doc : challanRequest.getChallan().getUploadedDocumentDetails()) {
+	                String tenant = challanRequest.getChallan().getTenantId();
+	                
+	                if ("CHALLAN.ID_PROOF".equals(doc.getDocumentType())) {
+	                	String imgUrl = util.getPublicUrlFromFilestore(doc.getFileStoreId(), tenant);
+
+	                	// 2. Fallback: If the first attempt returned null or empty, try the "pb" tenant
+	                	if (imgUrl == null || imgUrl.isEmpty()) {
+	                	    imgUrl = util.getPublicUrlFromFilestore(doc.getFileStoreId(), "pb");
+	                	}
+	                	if (imgUrl != null && !imgUrl.isEmpty()) {
+	                	    
+	                	    // Add to your attachments list...
+	                	    attachments.add(EmailAttachment.builder()
+	                	            .url(imgUrl)
+	                	            .contentId("evidence1") // or whatever ID you are assigning
+	                	            .mimeType("image/jpeg")
+	                	            .build());
+	                	}	                    
+	                }
+	                
+	                if ("CHALLAN.EVIDENCE_IMAGE".equals(doc.getDocumentType())) {
+	                	String imgUrl = util.getPublicUrlFromFilestore(doc.getFileStoreId(), tenant);
+
+	                	// 2. Fallback: If the first attempt returned null or empty, try the "pb" tenant
+	                	if (imgUrl == null || imgUrl.isEmpty()) {
+	                	    imgUrl = util.getPublicUrlFromFilestore(doc.getFileStoreId(), "pb");
+	                	}
+	                	if (imgUrl != null && !imgUrl.isEmpty()) {
+	                        attachments.add(EmailAttachment.builder()
+	                                .url(imgUrl)
+	                                .contentId("evidence2") // Maps to <img src="cid:evidence2">
+	                                .mimeType("image/jpeg")
+	                                .build());
+	                    }
+	                }
+	            }
+	        }
+
+	        Email emailobj = null;
+	        EmailRequest email = null;
+	        
+	        if (mapOfPhnoAndEmail.get(mobilenumber) != null) {
+	            emailobj = Email.builder()
+	                            .emailTo(Collections.singleton(mapOfPhnoAndEmail.get(mobilenumber)))
+	                            .isHTML(true)
+	                            .body(body)
+	                            .subject(subject)
+	                            .inlineAttachments(attachments) // Add the attachments payload here
+	                            .build();
+	                            
+	            email = new EmailRequest(challanRequest.getRequestInfo(), emailobj);
+	            log.info("Enriched EmailRequest: " + email);
+	            emailRequestList.add(email);
+	        }
+	    }
+	    else {
+	        log.error("No message configured! Notification will not be sent for challan: " + challanRequest.getChallan().getChallanNo());
+	    }
 	}
-	
+		/**
+	     * Determines the email subject based on the Workflow Action.
+	     */
+	    private String getSubjectBasedOnWorkflow(Challan challan, Workflow workflow) {
+	        String defaultSubject = "Municipal Challan Notice - " + challan.getChallanNo();
 
+	        // Null safety check: If workflow or action is missing, return the default subject
+	        if (workflow == null || workflow.getAction() == null || workflow.getAction().isEmpty()) {
+	            return defaultSubject;
+	        }
+
+	        String action = workflow.getAction().toUpperCase();
+
+	        // Set the subject based on the action
+	        if ("SUBMIT".equals(action)) {
+	            return "New Challan Generated -  " + challan.getChallanNo();
+	        } 
+	        else if ("APPLY".equals(action)) {
+	            return "New Challan Generated - " + challan.getChallanNo();
+	        } 
+	        else if ("CANCEL".equals(action)) {
+	            return "Challan Cancelled - " + challan.getChallanNo();
+	        } 
+	        else if ("PAY".equals(action)) {
+	            return "Payment Received for Challan - " + challan.getChallanNo();
+	        }
+
+	        // If the action is something else, return the default
+	        return defaultSubject;
+	    }
 }

--- a/municipal-services/challan-generation/src/main/java/org/egov/echallan/util/NotificationUtil.java
+++ b/municipal-services/challan-generation/src/main/java/org/egov/echallan/util/NotificationUtil.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static com.jayway.jsonpath.Criteria.where;
@@ -97,77 +98,270 @@ public class NotificationUtil {
 	     return message;
 	}
 	*/
-	private String getReplacedMsg(RequestInfo requestInfo,Challan challan, String message) {
-		if (challan.getApplicationStatus() != Challan.StatusEnum.CANCELLED) {
-			try {
-				String billDetails = getBillDetails(requestInfo, challan);
-				if (billDetails != null && !billDetails.isEmpty()) {
-					Object obj = JsonPath.parse(billDetails).read(BILL_AMOUNT_JSONPATH);
-					if (obj != null) {
-						BigDecimal amountToBePaid = new BigDecimal(obj.toString());
-						message = message.replace("<amount>", amountToBePaid.toString());
-						log.info("Replaced Amount");
-					} else {
-						// Fallback to challan amount if bill amount not available
-						if (challan.getChallanAmount() != null) {
-							message = message.replace("<amount>", challan.getChallanAmount().toString());
-						}
-					}
-				} else {
-					// Fallback to challan amount if bill details not available
-					if (challan.getChallanAmount() != null) {
-						message = message.replace("<amount>", challan.getChallanAmount().toString());
-					}
-				}
-			} catch (Exception e) {
-				log.warn("Failed to get bill amount for challan {}, using challan amount: {}", 
-					challan.getChallanNo(), e.getMessage());
-				// Fallback to challan amount
-				if (challan.getChallanAmount() != null) {
-					message = message.replace("<amount>", challan.getChallanAmount().toString());
-				}
-			}
-		}
+	private String getReplacedMsg(RequestInfo requestInfo, Challan challan, String message) {
+	    // ======================================================
+	    // CRITICAL CHECK 1: Ensure root objects are not null
+	    // ======================================================
+	    if (message == null || message.trim().isEmpty()) {
+	        log.error("Email template is NULL. Database localization is missing.");
+	        return "Your Municipal Challan has been generated. Please login to the portal to view details.";
+	    }
+	    if (challan == null) {
+	        log.error("Challan object is NULL inside getReplacedMsg.");
+	        return message;
+	    }
 
-		message = message.replace("{User}",challan.getCitizen().getName());
-        message = message.replace("<challanno>", challan.getChallanNo());
-		if(message.contains("{ULB}")) {
-			String[] tenantParts = challan.getTenantId().split("\\.");
-			if(tenantParts.length > 1) {
-				message = message.replace("{ULB}", capitalize(tenantParts[1]));
-			} else {
-				message = message.replace("{ULB}", capitalize(challan.getTenantId()));
-			}
-		}
+	    // ======================================================
+	    // CRITICAL CHECK 2: Safely extract nested variables
+	    // ======================================================
+	    String challanNo = challan.getChallanNo() != null ? challan.getChallanNo() : "N/A";
+	    String tenantId = challan.getTenantId() != null ? challan.getTenantId() : "pb";
+	    
+	    String citizenName = "Citizen";
+	    String mobileNo = "N/A";
+	    if (challan.getCitizen() != null) {
+	        citizenName = challan.getCitizen().getName() != null ? challan.getCitizen().getName() : "Citizen";
+	        mobileNo = challan.getCitizen().getMobileNumber() != null ? challan.getCitizen().getMobileNumber() : "N/A";
+	    }
 
-		// Handle businessService - it may or may not contain a dot
-		String businessServiceStr = challan.getBusinessService();
-		String service = "";
-		if(businessServiceStr != null) {
-			String[] businessServiceParts = businessServiceStr.split("\\.");
-			String serviceName = businessServiceParts.length > 1 ? businessServiceParts[1] : businessServiceParts[0];
-			String[] split_array = capitalize(serviceName).split("_");
-			service = String.join(" ", split_array);
-		}
+	    String employeeName = "Enforcement Officer";
+	    if (requestInfo != null && requestInfo.getUserInfo() != null && requestInfo.getUserInfo().getName() != null) {
+	        employeeName = requestInfo.getUserInfo().getName();
+	    }
 
-        String UIHost = config.getUiAppHost();
-		String paymentPath = config.getPayLinkSMS();
-		paymentPath = paymentPath.replace("$consumercode",challan.getChallanNo());
-		paymentPath = paymentPath.replace("$tenantId",challan.getTenantId());
-		paymentPath = paymentPath.replace("$businessservice",challan.getBusinessService());
-		//String finalPath = UIHost + paymentPath;
-		/*
-		 * if(message.contains("{Link}")) message =
-		 * message.replace("{Link}",getShortenedUrl(finalPath));
-		 */
-		String result = truncateAndSplitString(service, 33);
-		message = message.replace("<service>", result);
-		String newLink = "https://mseva.lgpunjab.gov.in/citizen";
-		String updatedMessage = message.replace("<Link>", newLink);
 
-        log.info("update"+updatedMessage);
-		log.info("Final msg after all rep: "+updatedMessage);
-        return updatedMessage;
+	    // ==========================================
+	    // 1. ORIGINAL LEGACY CODE
+	    // ==========================================
+	    if (challan.getApplicationStatus() != null && challan.getApplicationStatus() != Challan.StatusEnum.CANCELLED) {
+	        try {
+	            String billDetails = getBillDetails(requestInfo, challan);
+	            if (billDetails != null && !billDetails.isEmpty()) {
+	                Object obj = JsonPath.parse(billDetails).read(BILL_AMOUNT_JSONPATH);
+	                if (obj != null) {
+	                    BigDecimal amountToBePaid = new BigDecimal(obj.toString());
+	                    message = message.replace("<amount>", amountToBePaid.toString());
+	                    message = message.replace("{totalAmount}", amountToBePaid.toString());
+	                } else if (challan.getChallanAmount() != null) {
+	                    message = message.replace("<amount>", challan.getChallanAmount().toString());
+	                    message = message.replace("{totalAmount}", challan.getChallanAmount().toString());
+	                }
+	            } else if (challan.getChallanAmount() != null) {
+	                message = message.replace("<amount>", challan.getChallanAmount().toString());
+	                message = message.replace("{totalAmount}", challan.getChallanAmount().toString());
+	            }
+	        } catch (Exception e) {
+	            log.warn("Failed to get bill amount for challan {}, using challan amount: {}", challanNo, e.getMessage());
+	            if (challan.getChallanAmount() != null) {
+	                message = message.replace("<amount>", challan.getChallanAmount().toString());
+	                message = message.replace("{totalAmount}", challan.getChallanAmount().toString());
+	            }
+	        }
+	    }
+
+	    message = message.replace("{User}", citizenName);
+	    message = message.replace("<challanno>", challanNo);
+	    
+	    if (message.contains("{ULB}") && tenantId != null) {
+	        String[] tenantParts = tenantId.split("\\.");
+	        String ulbName = (tenantParts.length > 1) ? capitalize(tenantParts[1]) : capitalize(tenantId);
+	        message = message.replace("{ULB}", ulbName);
+	    }
+
+	    String businessServiceStr = challan.getBusinessService();
+	    String service = "";
+	    if (businessServiceStr != null) {
+	        String[] businessServiceParts = businessServiceStr.split("\\.");
+	        String serviceName = businessServiceParts.length > 1 ? businessServiceParts[1] : businessServiceParts[0];
+	        String[] split_array = capitalize(serviceName).split("_");
+	        service = String.join(" ", split_array);
+	    }
+
+	    // CRITICAL CHECK 3: Ensure Config isn't null before calling .replace()
+	    String paymentPath = (config != null) ? config.getPayLinkSMS() : null;
+	    if (paymentPath != null) {
+	        paymentPath = paymentPath.replace("$consumercode", challanNo);
+	        paymentPath = paymentPath.replace("$tenantId", tenantId);
+	        paymentPath = paymentPath.replace("$businessservice", businessServiceStr != null ? businessServiceStr : "");
+	    }
+
+	    String result = truncateAndSplitString(service, 33);
+	    message = message.replace("<service>", result != null ? result : "");
+	    
+	    String portalFallbackLink = "https://mseva.lgpunjab.gov.in/citizen";
+	    message = message.replace("<Link>", portalFallbackLink);
+
+
+	    // ==========================================
+	    // 2. NEW PROFESSIONAL TEMPLATE MAPPINGS
+	    // ==========================================
+	    
+	    message = message.replace("{challanNumber}", challanNo);
+	    message = message.replace("{citizenName}", citizenName);
+	    message = message.replace("{mobileNumber}", mobileNo);
+	    message = message.replace("{employeeName}", employeeName);
+	    
+	    String address = "Address not provided";
+	    if (challan.getAddress() != null && challan.getAddress().getAddressLine1() != null) {
+	        address = challan.getAddress().getAddressLine1();
+	    }
+	    message = message.replace("{address}", address);
+	    
+	    String cityName = "Municipal";
+	    if (tenantId != null) {
+	        String[] tenantParts = tenantId.split("\\.");
+	        if (tenantParts.length > 1) {
+	            cityName = capitalize(tenantParts[1]); 
+	        } else {
+	            cityName = capitalize(tenantId);
+	        }
+	    }
+	    message = message.replace("{cityName}", cityName != null ? cityName : "Municipal");
+	    
+	    SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
+	    message = message.replace("{createdDate}", sdf.format(new Date(System.currentTimeMillis())));
+
+	    message = message.replace("{offenceCategory}", challan.getOffenceCategoryName() != null ? challan.getOffenceCategoryName() : "General Violation");
+	    message = message.replace("{offenceType}", challan.getOffenceSubCategoryName() != null ? challan.getOffenceSubCategoryName() : "Municipal Offence");
+	    message = message.replace("{offenceDescription}", challan.getOffenceTypeName() != null ? challan.getOffenceTypeName() : "Violation of Municipal Bye-Laws");
+	    
+	    String act = "Punjab Municipal Bye-Laws";
+	    if (challan.getAdditionalDetail() instanceof java.util.Map) {
+	        java.util.Map<String, Object> ad = (java.util.Map<String, Object>) challan.getAdditionalDetail();
+	        if (ad.get("offenceActs") != null) {
+	            act = ad.get("offenceActs").toString();
+	        }
+	    }
+	    message = message.replace("{offenceAct}", act);
+
+
+	    // ==========================================
+	    // 3. DOCUMENT AND PDF URL MAPPINGS
+	    // ==========================================
+
+	    String officialPdfUrl = getPdfAndPublicUrl(challan, requestInfo);
+	    message = message.replace("{pdfDownloadUrl}", officialPdfUrl != null ? officialPdfUrl : portalFallbackLink);
+
+	    return message;
+	}
+	
+	// =========================================================
+    // HELPER METHODS FOR PDF GENERATION (Paste inside NotificationUtil)
+    // =========================================================
+
+    public String getPdfAndPublicUrl(Challan challan, RequestInfo requestInfo) {
+        try {
+            // Using config to get the host (Ensure config.getPdfServiceHost() exists in your ChallanConfiguration)
+            String pdfUrl = config.getPdfServiceHost() + "/pdf-service/v1/_create?tenantId=" + challan.getTenantId() + "&key=challan-notice";
+            
+            java.util.Map<String, Object> pdfRequest = new java.util.HashMap<>();
+            pdfRequest.put("RequestInfo", requestInfo);
+            pdfRequest.put("challan", preparePdfData(challan, requestInfo)); 
+
+            // Call PDF Service
+            java.util.Map<String, Object> response = restTemplate.postForObject(pdfUrl, pdfRequest, java.util.Map.class);
+            
+            if (response != null && response.get("filestoreIds") != null) {
+                java.util.List<String> filestoreIds = (java.util.List<String>) response.get("filestoreIds");
+                if (!filestoreIds.isEmpty()) {
+                    String pdfFileStoreId = filestoreIds.get(0);
+                    // Get the public URL for the newly generated PDF
+                    return getPublicUrlFromFilestore(pdfFileStoreId, challan.getTenantId());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to generate PDF for challan: " + challan.getChallanNo(), e);
+        }
+        // Fallback if PDF generation fails
+        return "https://mseva.lgpunjab.gov.in/citizen"; 
+    }
+ // =========================================================
+    // HELPER METHOD FOR FILESTORE IMAGES
+    // =========================================================
+    public String getPublicUrlFromFilestore(String fileStoreId, String tenantId) {
+        if (fileStoreId == null || fileStoreId.isEmpty()) return "";
+
+        try {
+            // Build the internal API URL using your config
+            String url = config.getFileStoreHost() + config.getFileStoreViewPath()
+                       + "?tenantId=" + tenantId
+                       + "&fileStoreIds=" + fileStoreId;
+            log.info("Fetching public URL from Filestore API for fileStoreId: {} with URL: {}", fileStoreId, url);
+            // Fetch the response from the Filestore API
+            java.util.Map<String, Object> response = restTemplate.getForObject(url, java.util.Map.class);
+
+            String devUrl = null;
+
+            if (response != null) {
+                // OPTION 1: Check if the ID is a direct key in the map (Common in mSeva)
+                if (response.containsKey(fileStoreId)) {
+                    devUrl = (String) response.get(fileStoreId);
+                }
+                // OPTION 2: Check if it is nested inside the fileStoreIds list
+                else if (response.get("fileStoreIds") instanceof java.util.List) {
+                    java.util.List<java.util.Map<String, Object>> fileList = 
+                        (java.util.List<java.util.Map<String, Object>>) response.get("fileStoreIds");
+                    
+                    for (java.util.Map<String, Object> fileData : fileList) {
+                        if (fileStoreId.equals(fileData.get("id"))) {
+                            devUrl = (String) fileData.get("url");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // CRITICAL FIX: Return the pure, direct URL. 
+            // The central mail service will handle downloading it into memory.
+            if (devUrl != null && !devUrl.isEmpty()) {
+            	log.info("Successfully retrieved public URL from Filestore API for fileStoreId {}: {}", fileStoreId, devUrl);
+                return devUrl;
+            }
+
+        } catch (Exception e) {
+            log.error("Filestore API Error for ID " + fileStoreId, e);
+        }
+        
+        // Return empty string if failed so the fallback logic triggers
+        return "";
+    }
+    
+    
+    private java.util.Map<String, Object> preparePdfData(Challan challan, RequestInfo requestInfo) {
+        java.util.Map<String, Object> pdfData = new java.util.HashMap<>();
+
+        // 1. Wrap the single challan into a List
+        java.util.List<Challan> challanList = new java.util.ArrayList<>();
+        challanList.add(challan);
+        pdfData.put("challans", challanList);
+        pdfData.put("countOfServices", 1);
+        
+        // 2. Calculate Total Amount
+        java.math.BigDecimal totalAmount = java.math.BigDecimal.ZERO;
+        if (challan.getAmount() != null) {
+            for (Amount amt : challan.getAmount()) {
+                if (amt.getAmount() != null) {
+                    totalAmount = totalAmount.add(amt.getAmount()); 
+                }
+            }
+        }
+        pdfData.put("totalAmountCollected", totalAmount);
+        
+        // 3. Map the Officer/Employee details
+        java.util.Map<String, Object> officer = new java.util.HashMap<>();
+        if (requestInfo != null && requestInfo.getUserInfo() != null) {
+            officer.put("name", requestInfo.getUserInfo().getName());
+            officer.put("code", requestInfo.getUserInfo().getUserName());
+        } else {
+            officer.put("name", "System");
+            officer.put("code", "SYS");
+        }
+        pdfData.put("officer", officer);
+
+        // 4. Add Location
+        pdfData.put("location", (challan.getAddress() != null) ? challan.getAddress().getAddressLine1() : "Address not provided");
+
+        return pdfData;
     }
 	public static String truncateAndSplitString(String inputString, int truncateLength) {
         if (inputString.length() <= truncateLength) {
@@ -286,8 +480,8 @@ public class NotificationUtil {
 		StringBuilder uri = new StringBuilder();
 		uri.append(config.getLocalizationHost()).append(config.getLocalizationContextPath())
 				.append(config.getLocalizationSearchEndpoint()).append("?").append("locale=").append(locale)
-				.append("&tenantId=").append(tenantId).append("&module=").append(MODULE)
-				.append("&codes=").append(CODES);
+				.append("&tenantId=").append(tenantId).append("&module=").append(MODULE);
+//				.append("&codes=").append(CODES);
 
 		return uri;
 	}
@@ -361,8 +555,8 @@ public class NotificationUtil {
 				log.debug("Messages from localization couldn't be fetched!");
 			for (EmailRequest emailRequest : emailRequestList) {
 				producer.push(config.getEmailNotifTopic(), emailRequest);
-				log.debug("Email Request -> "+emailRequest.getEmail().toString());
-				log.debug("EMAIL notification sent!");
+				log.info("Email Request -> "+emailRequest.getEmail().toString());
+				log.info("EMAIL notification sent!");
 			}
 		}
 	}

--- a/municipal-services/challan-generation/src/main/resources/application.properties
+++ b/municipal-services/challan-generation/src/main/resources/application.properties
@@ -140,10 +140,10 @@ egov.localization.statelevel=true
 #SMS Notification
 kafka.topics.notification.sms=egov.core.notification.sms
 notification.sms.enabled=true
-kafka.topics.notification.email=egov.core.notification.email
+kafka.topics.notification.email=org.egov.core.notification.email
 notification.email.enabled=true
 # Disable all notifications (set to false to skip notification service when localization messages are not configured)
-notification.enabled=false
+notification.enabled=true
 
 #businessServices allowed
 egov.allowed.businessServices=TL,BPAREG
@@ -179,3 +179,9 @@ egov.collection.service.search.endpoint=/collection-services/payments/
 egov.download.receipt.link=/citizen/otpLogin?mobileNo=$mobile&redirectTo=egov-common/download-receipt?status=success&consumerCode=$consumerCode&tenantId=$tenantId&receiptNumber=$receiptNumber&businessService=$businessService&smsLink=true&mobileNo=$mobile
 egov.dynamicdata.period=12
 egov.echallan.validity=1
+
+egov.pdf.service.host=https://sdc-uat.lgpunjab.gov.in
+egov.pdf.service.create.endpoint=/pdf-service/v1/_create
+
+
+egov.filestore.view.endpoint=/filestore/v1/files/url


### PR DESCRIPTION
Add support for inline email attachments and filestore/pdf integration for challan emails. Changes include:

- core-services: add EmailAttachment model and inlineAttachments to Email; make ExternalEmailService @Async to avoid Kafka/broker blocking; process new inline EmailAttachment objects (addInline) while preserving legacy string-URL attachments handling, reduce timeouts and improve logging.
- municipal-services (challan-generation): add EmailAttachment model and include inlineAttachments in Email model; extend ChallanConfiguration with pdf/filestore hosts and endpoints; re-enable email notification flow in NotificationService and enrichEmailRequest now builds inline attachment payloads from uploaded documents, sets subject based on workflow, and logs enriched requests.
- NotificationUtil: harden template replacements, add PDF generation helper (calls pdf-service), add getPublicUrlFromFilestore to resolve fileStoreId -> public URL, and preparePdfData used for PDF requests.
- ServiceRequestRepository: silence a request-body log.
- application.properties: switch email topic, enable notifications, and add pdf/filestore endpoints.

These changes enable embedding images (cid:) in challan emails, generate PDFs via the pdf-service, and make email sending non-blocking and more resilient when downloading attachments.