### PR TITLE
Increase default demand query limit to 1000

### DIFF
--- a/business-services/billing-service/src/main/java/org/egov/demand/repository/querybuilder/DemandQueryBuilder.java
+++ b/business-services/billing-service/src/main/java/org/egov/demand/repository/querybuilder/DemandQueryBuilder.java
@@ -236,7 +236,7 @@ public class DemandQueryBuilder {
 
 	private static void addPagingClause(StringBuilder demandQueryBuilder, List<Object> preparedStatementValues) {
 		demandQueryBuilder.append(" LIMIT ?");
-		preparedStatementValues.add(500);
+		preparedStatementValues.add(1000);
 		demandQueryBuilder.append(" OFFSET ?");
 		preparedStatementValues.add(0);
 	}


### PR DESCRIPTION
Update addPagingClause in DemandQueryBuilder to use a default LIMIT of 1000 (was 500). This increases the default page size for demand queries by changing the prepared statement value, reducing the number of paged requests required to retrieve larger result sets.