### PR TITLE
Add ES fuzzy search and Kafka improvements

### DIFF
--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/config/SWConfiguration.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/config/SWConfiguration.java
@@ -237,5 +237,20 @@ public class SWConfiguration {
     
     @Value("${egov.billing.service.host}")
 	private String businesserviceHost;
+    
+    @Value("${egov.es.host}")
+    private String elasticsearchHost;
+    
+    @Value("${egov.es.search.endpoint}")
+    private String elasticsearchSearchEndpoint;
+    
+    @Value("${egov.sw.enriched.index}") // This matches your application properties key
+    private String swIndex;
+
+    @Value("${elasticsearch.username:}")
+    private String elasticsearchUsername;
+
+    @Value("${elasticsearch.password:}")
+    private String elasticsearchPassword;
 
 }

--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/repository/ElasticSearchRepository.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/repository/ElasticSearchRepository.java
@@ -1,0 +1,89 @@
+package org.egov.swservice.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import org.egov.swservice.config.SWConfiguration;
+import org.egov.swservice.repository.builder.SWFuzzySearchQueryBuilder;
+import org.egov.swservice.web.models.SearchCriteria;
+import org.egov.tracer.model.CustomException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+public class ElasticSearchRepository {
+
+    private SWConfiguration config; // Updated to SW
+
+    private SWFuzzySearchQueryBuilder queryBuilder; // Updated to SW
+
+    private RestTemplate restTemplate;
+
+    private ObjectMapper mapper;
+
+    @Autowired
+    public ElasticSearchRepository(SWConfiguration config, SWFuzzySearchQueryBuilder queryBuilder, 
+                                   RestTemplate restTemplate, ObjectMapper mapper) {
+        this.config = config;
+        this.queryBuilder = queryBuilder;
+        this.restTemplate = restTemplate;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Searches records from elasticsearch based on the fuzzy search criteria for Sewerage Connections
+     *
+     * @param criteria SewerageConnection search criteria
+     * @return Object (ElasticSearch Response Body)
+     */
+    public Object fuzzySearchForConnections(SearchCriteria criteria) {
+
+        String url = getESURL();
+
+        // Generates the JSON query string for ES using the SW Query Builder
+        String searchQuery = queryBuilder.getFuzzySearchQuery(criteria);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (config.getElasticsearchUsername() != null && !config.getElasticsearchUsername().isEmpty() &&
+            config.getElasticsearchPassword() != null && !config.getElasticsearchPassword().isEmpty()) {
+            headers.setBasicAuth(config.getElasticsearchUsername(), config.getElasticsearchPassword());
+        }
+        HttpEntity<String> requestEntity = new HttpEntity<>(searchQuery, headers);
+
+        log.info("ES SW Search URL: {} | Request Body: {}", url, searchQuery);
+
+        ResponseEntity<Object> response = null;
+        try {
+            response = restTemplate.postForEntity(url, requestEntity, Object.class);
+        } catch (Exception e) {
+            log.error("Error occurred while fetching data from ElasticSearch for SW", e);
+            throw new CustomException("ES_ERROR", "Failed to fetch data from ES for Sewerage Connections");
+        }
+
+        return response != null ? response.getBody() : null;
+    }
+
+    /**
+     * Generates elasticsearch search url from sewerage-service application properties
+     *
+     * @return Full ES search URL
+     */
+    private String getESURL() {
+
+        StringBuilder builder = new StringBuilder(config.getElasticsearchHost());
+        
+        // Ensure SWConfiguration has the property for the sewerage index name
+        builder.append(config.getSwIndex()); 
+        builder.append(config.getElasticsearchSearchEndpoint());
+
+        return builder.toString();
+    }
+}

--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/repository/builder/SWFuzzySearchQueryBuilder.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/repository/builder/SWFuzzySearchQueryBuilder.java
@@ -1,0 +1,162 @@
+package org.egov.swservice.repository.builder;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.egov.swservice.config.SWConfiguration;
+import org.egov.swservice.web.models.SearchCriteria;
+import org.egov.tracer.model.CustomException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class SWFuzzySearchQueryBuilder {
+
+    private ObjectMapper mapper;
+    private SWConfiguration config; // Updated to SW config
+
+    @Autowired
+    public SWFuzzySearchQueryBuilder(ObjectMapper mapper, SWConfiguration config) {
+        this.mapper = mapper;
+        this.config = config;
+    }
+
+    private static final String BASE_QUERY = "{\n" +
+            "  \"from\": {{OFFSET}},\n" +
+            "  \"size\": {{LIMIT}},\n" +
+            "  \"sort\": {\n" +
+            "    \"Data.auditDetails.createdTime\": { \"order\": \"desc\" }\n" +
+            "  },\n" +
+            "  \"query\": {}\n" +
+            "}";
+
+    private static final String wildCardQueryTemplate = "{\"query_string\": {\"default_field\": \"{{VAR}}\", \"query\": \"*{{PARAM}}*\"}}";
+    private static final String queryTemplate = "{\"query_string\": {\"default_field\": \"{{VAR}}\", \"query\": \"{{PARAM}}\"}}";
+
+    public String getFuzzySearchQuery(SearchCriteria criteria) {
+        try {
+            String baseQuery = addPagination(criteria);
+            JsonNode node = mapper.readTree(baseQuery);
+            ObjectNode insideMatch = (ObjectNode) node.get("query");
+            List<JsonNode> mustList = new LinkedList<>();
+
+            // 1. Tenant Filter
+            if (criteria.getTenantId() != null) {
+                mustList.add(getInnerNode(criteria.getTenantId(), "Data.tenantId", false));
+            }
+
+            // 2. Owner Name Filter (Checks additionalDetails OR connectionHolders)
+            if (criteria.getOwnerName() != null) {
+                List<JsonNode> nameShouldClauses = new LinkedList<>();
+                nameShouldClauses.add(getInnerNode(criteria.getOwnerName(), "Data.additionalDetails.ownerName", true));
+                nameShouldClauses.add(getInnerNode(criteria.getOwnerName(), "Data.connectionHolders.name", true));
+
+                Map<String, Object> shouldBool = new HashMap<>();
+                shouldBool.put("should", nameShouldClauses);
+                shouldBool.put("minimum_should_match", 1);
+                
+                mustList.add(mapper.convertValue(new HashMap<String, Object>() {{ put("bool", shouldBool); }}, JsonNode.class));
+            }
+
+            // 3. Sewerage Connection Number
+            if (!CollectionUtils.isEmpty(criteria.getConnectionNumber())) {
+                for (String connNo : criteria.getConnectionNumber()) {
+                    mustList.add(getInnerNode(connNo, "Data.connectionNo.keyword", false));
+                }
+            }
+
+            // 4. Application Number
+            if (!CollectionUtils.isEmpty(criteria.getApplicationNumber())) {
+                for (String appNo : criteria.getApplicationNumber()) {
+                    mustList.add(getInnerNode(appNo, "Data.applicationNo.keyword", false));
+                }
+            }
+
+            // 5. Mobile Number
+            if (criteria.getMobileNumber() != null) {
+                mustList.add(getInnerNode(criteria.getMobileNumber(), "Data.connectionHolders.mobileNumber.keyword", false));
+            }
+
+            // 6. Property ID
+            if (criteria.getPropertyId() != null) {
+                mustList.add(getInnerNode(criteria.getPropertyId(), "Data.propertyId.keyword", false));
+            }
+
+            // 7. Locality
+            if (criteria.getLocality() != null) {
+                mustList.add(getInnerNode(criteria.getLocality(), "Data.additionalDetails.locality", false));
+            }
+
+            // 8. Application Status
+            if (criteria.getStatus() != null) {
+                mustList.add(getInnerNode(criteria.getStatus(), "Data.applicationStatus.keyword", false));
+            }
+
+            // 9. Date Range Filter
+            if (criteria.getFromDate() != null || criteria.getToDate() != null) {
+                Map<String, Object> rangeParams = new HashMap<>();
+                if (criteria.getFromDate() != null) rangeParams.put("gte", criteria.getFromDate());
+                if (criteria.getToDate() != null) rangeParams.put("lte", criteria.getToDate());
+                
+                Map<String, Object> rangeField = new HashMap<>();
+                rangeField.put("Data.auditDetails.createdTime", rangeParams);
+                mustList.add(mapper.convertValue(new HashMap<String, Object>() {{ put("range", rangeField); }}, JsonNode.class));
+            }
+
+            // Final query assembly
+            Map<String, Object> boolMap = new HashMap<>();
+            boolMap.put("must", mustList);
+            insideMatch.set("bool", mapper.convertValue(boolMap, JsonNode.class));
+
+            return mapper.writeValueAsString(node);
+
+        } catch (Exception e) {
+            log.error("ES_SW_QUERY_BUILDER_ERROR", e);
+            throw new CustomException("QUERY_BUILD_ERROR", "Failed to build JSON query for Sewerage Connection fuzzy search");
+        }
+    }
+
+    private JsonNode getInnerNode(String param, String var, boolean isWildCard) throws JsonProcessingException {
+        String template = isWildCard ? wildCardQueryTemplate : queryTemplate;
+        String innerQuery = template.replace("{{PARAM}}", getEscapedString(param));
+        innerQuery = innerQuery.replace("{{VAR}}", var);
+        return mapper.readTree(innerQuery);
+    }
+
+    private String addPagination(SearchCriteria criteria) {
+        Long limit = config.getDefaultLimit().longValue();
+        Long offset = config.getDefaultOffset().longValue();
+
+        if (criteria.getLimit() != null) {
+            limit = Math.min(criteria.getLimit().longValue(), config.getMaxLimit().longValue());
+        }
+        if (criteria.getOffset() != null) {
+            offset = criteria.getOffset().longValue();
+        }
+
+        return BASE_QUERY.replace("{{OFFSET}}", offset.toString())
+                         .replace("{{LIMIT}}", limit.toString());
+    }
+
+    private String getEscapedString(String inputString) {
+        final String[] metaCharacters = {"\\", "/", "^", "$", "{", "}", "[", "]", "(", ")", "*", "+", "?", "|", "<", ">", "-", "&", "%"};
+        for (String character : metaCharacters) {
+            if (inputString.contains(character)) {
+                inputString = inputString.replace(character, "\\\\" + character);
+            }
+        }
+        return inputString;
+    }
+}

--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/service/SWFuzzySearchService.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/service/SWFuzzySearchService.java
@@ -1,0 +1,174 @@
+package org.egov.swservice.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.swservice.repository.ElasticSearchRepository;
+import org.egov.swservice.repository.SewerageDaoImpl;
+import org.egov.swservice.web.models.*;
+import org.egov.tracer.model.CustomException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+
+import lombok.extern.slf4j.Slf4j;
+
+//Note the 'static' keyword and the '*' or specific variable name
+import static org.egov.swservice.util.SWConstants.ES_DATA_PATH;
+
+
+
+@Service
+@Slf4j
+public class SWFuzzySearchService {
+
+    private ElasticSearchRepository elasticSearchRepository;
+    private ObjectMapper mapper;
+    private SewerageDaoImpl sewerageDao; // Changed from WaterDaoImpl
+
+    @Autowired
+    public SWFuzzySearchService(ElasticSearchRepository elasticSearchRepository, ObjectMapper mapper, SewerageDaoImpl repository) {
+        this.elasticSearchRepository = elasticSearchRepository;
+        this.mapper = mapper;
+        this.sewerageDao = repository;
+    }
+
+    /**
+     * Executes fuzzy search by coordinating between ES and the Database for Sewerage Connections.
+     * * @param requestInfo Standard eGov request metadata
+     * @param criteria Search parameters (name, connectionNo, etc.)
+     * @return Ordered list of SewerageConnections
+     */
+    public List<SewerageConnection> getConnections(RequestInfo requestInfo, SearchCriteria criteria) {
+
+        log.info("Initiating SW fuzzy search with criteria: {}", criteria);
+
+        // 1. Validate that at least one fuzzy field is provided
+        validateFuzzySearchCriteria(criteria);
+
+        // 2. Search ElasticSearch for matching IDs
+        Object esResponse = elasticSearchRepository.fuzzySearchForConnections(criteria);
+
+        // 3. Extract IDs and group by TenantId
+        Map<String, Set<String>> tenantIdToConnectionNos = getTenantIdToConnectionNoMap(esResponse);
+
+        if (CollectionUtils.isEmpty(tenantIdToConnectionNos)) {
+            return new LinkedList<>();
+        }
+
+        List<SewerageConnection> connections = new LinkedList<>();
+
+        // 4. Hydrate full connection data from DB
+        for (Map.Entry<String, Set<String>> entry : tenantIdToConnectionNos.entrySet()) {
+            
+            SearchCriteria dbCriteria = SearchCriteria.builder()
+                    .tenantId(entry.getKey())
+                    .connectionNumber(entry.getValue())
+                    .build();
+
+            // Fetching from DB ensures we have the latest owner/connection details
+            connections.addAll(sewerageDao.getSewerageConnectionList(dbCriteria, requestInfo));
+        }
+
+        // 5. Restore the order of results based on ElasticSearch relevance score
+        return orderByESScore(connections, esResponse);
+    }
+
+    /**
+     * Re-sorts the DB results to match the ranking (score) provided by ES.
+     */
+    private List<SewerageConnection> orderByESScore(List<SewerageConnection> connections, Object esResponse) {
+
+        List<SewerageConnection> orderedConnections = new LinkedList<>();
+
+        if (!CollectionUtils.isEmpty(connections)) {
+            Map<String, SewerageConnection> idToConnectionMap = new LinkedHashMap<>();
+
+            // Map connections by their business identifier (Connection Number)
+            connections.forEach(conn -> idToConnectionMap.put(conn.getConnectionNo(), conn));
+
+            try {
+                // ES_DATA_PATH should be defined in SWConstants (usually "$.hits.hits.._source.Data")
+                List<Map<String, Object>> data = JsonPath.read(esResponse, ES_DATA_PATH);
+
+                if (!CollectionUtils.isEmpty(data)) {
+                    for (Map<String, Object> map : data) {
+                        String connNo = JsonPath.read(map, "$.connectionNo");
+                        if (idToConnectionMap.containsKey(connNo)) {
+                            orderedConnections.add(idToConnectionMap.get(connNo));
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to parse ES response during ordering phase for SW", e);
+                throw new CustomException("PARSING_ERROR", "Failed to extract connectionNos from ES response");
+            }
+        }
+
+        return orderedConnections;
+    }
+
+    /**
+     * Parses the ES response to create a map of TenantId to ConnectionNumbers.
+     */
+    private Map<String, Set<String>> getTenantIdToConnectionNoMap(Object esResponse) {
+
+        Map<String, Set<String>> tenantIdToConnectionNos = new LinkedHashMap<>();
+
+        try {
+            List<Map<String, Object>> data = JsonPath.read(esResponse, ES_DATA_PATH);
+
+            if (!CollectionUtils.isEmpty(data)) {
+                for (Map<String, Object> map : data) {
+                    String tenantId = JsonPath.read(map, "$.tenantId");
+                    String connectionNo = JsonPath.read(map, "$.connectionNo");
+
+                    if (tenantId != null && connectionNo != null && !connectionNo.trim().isEmpty()) {
+                        tenantIdToConnectionNos
+                            .computeIfAbsent(tenantId, k -> new HashSet<>())
+                            .add(connectionNo);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to parse ES response during ID extraction for SW", e);
+            throw new CustomException("PARSING_ERROR", "Failed to extract connection data from ES response");
+        }
+
+        return tenantIdToConnectionNos;
+    }
+
+    /**
+     * Ensures search parameters are valid for a fuzzy search in SW.
+     */
+    private void validateFuzzySearchCriteria(SearchCriteria criteria) {
+
+        if (criteria.getTenantId() == null || criteria.getTenantId().trim().isEmpty()) {
+            throw new CustomException("EG_SW_SEARCH_TENANTID_MANDATORY", "TenantId is mandatory for all search operations.");
+        }
+
+        if (criteria.getOwnerName() != null && criteria.getLocality() == null) {
+            throw new CustomException("EG_SW_SEARCH_LOCALITY_MANDATORY", "Locality is mandatory when searching by Owner Name.");
+        }
+
+        if (CollectionUtils.isEmpty(criteria.getConnectionNumber()) && 
+            criteria.getOldConnectionNumber() == null && 
+            criteria.getOwnerName() == null && 
+            criteria.getDoorNo() == null &&
+            criteria.getLocality() == null
+            ) {
+            
+            throw new CustomException("INVALID_SEARCH_CRITERIA", "Please provide at least one search parameter for Sewerage connection search.");
+        }
+    }
+}

--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/util/SWConstants.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/util/SWConstants.java
@@ -410,5 +410,5 @@ public class SWConstants {
 	public static final String INACTIVE_STATUS = "Inactive";
 
 	public static final String SUCCESS_DISCONNECT_MSG = "Successfully disconnected sewerage connection";
-
+	public static final String ES_DATA_PATH = "$..Data";
 }

--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/web/controller/SewarageController.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/web/controller/SewarageController.java
@@ -5,7 +5,9 @@ import java.util.List;
 import javax.validation.Valid;
 
 import org.egov.swservice.service.SewerageEncryptionService;
+import org.egov.common.contract.request.RequestInfo;
 import org.egov.swservice.service.DocumentService;
+import org.egov.swservice.service.SWFuzzySearchService;
 import org.egov.swservice.web.models.DocumentRequest;
 import org.egov.swservice.web.models.RequestInfoWrapper;
 import org.egov.swservice.web.models.SearchCriteria;
@@ -45,6 +47,9 @@ public class SewarageController {
 
 	@Autowired
 	SewerageEncryptionService sewerageEncryptionService;
+	
+	@Autowired
+	private SWFuzzySearchService swFuzzySearchService;
 
 	@Autowired
 	private final ResponseInfoFactory responseInfoFactory;
@@ -62,18 +67,35 @@ public class SewarageController {
 	}
 
 	@RequestMapping(value = "/_search", method = RequestMethod.POST)
-	public ResponseEntity<SewerageConnectionResponse> search(@Valid @RequestBody RequestInfoWrapper requestInfoWrapper,
-			@Valid @ModelAttribute SearchCriteria criteria) {
-		List<SewerageConnection> sewerageConnectionList = sewarageService.search(criteria,
-				requestInfoWrapper.getRequestInfo());
-		Integer count = sewarageService.countAllSewerageApplications(criteria,	requestInfoWrapper.getRequestInfo());
-		SewerageConnectionResponse response = SewerageConnectionResponse.builder()
-				.sewerageConnections(sewerageConnectionList).totalCount(count)
-				.responseInfo(responseInfoFactory
-						.createResponseInfoFromRequestInfo(requestInfoWrapper.getRequestInfo(), true))
-				.build();
-		return new ResponseEntity<>(response, HttpStatus.OK);
-
+	public ResponseEntity<SewerageConnectionResponse> search(
+	        @Valid @RequestBody RequestInfoWrapper requestInfoWrapper,
+	        @Valid @ModelAttribute SearchCriteria criteria) {
+	    
+	    // 1. FIX: Extract requestInfo from the wrapper
+	    RequestInfo requestInfo = requestInfoWrapper.getRequestInfo();
+	    
+	    List<SewerageConnection> sewerageConnectionList = null;
+	    
+	    if (criteria.getOwnerName() != null || criteria.getDoorNo() != null || criteria.getLocality() != null) {
+	        // 2. FIX: Assign to the list instead of returning directly
+	        sewerageConnectionList = swFuzzySearchService.getConnections(requestInfo, criteria);
+	    } 
+	    else {
+	        // 2. FIX: Assign to the list instead of returning directly
+	        sewerageConnectionList = sewarageService.search(criteria, requestInfo);
+	    }
+	    
+	    // Now this code is reachable and will actually execute
+	    Integer count = sewarageService.countAllSewerageApplications(criteria, requestInfo);
+	    
+	    SewerageConnectionResponse response = SewerageConnectionResponse.builder()
+	            .sewerageConnections(sewerageConnectionList)
+	            .totalCount(count)
+	            .responseInfo(responseInfoFactory
+	                    .createResponseInfoFromRequestInfo(requestInfo, true))
+	            .build();
+	            
+	    return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/_update", method = RequestMethod.POST, produces = "application/json")

--- a/municipal-services/sw-services/src/main/resources/application.properties
+++ b/municipal-services/sw-services/src/main/resources/application.properties
@@ -192,3 +192,11 @@ eodb.update.url=https://pbindustries.gov.in/testportalnode/api/lg/UpdateStatus
 eodb.integration.key=UAT_LG
 
 kafka.consumer.config.concurrency.count=3
+
+egov.es.host=http://elasticsearch-data.es-cluster:9200/
+egov.sw.enriched.index=sewerage-services
+egov.es.search.endpoint=_search
+
+# optional basic authentication credentials for Elasticsearch:
+elasticsearch.username=
+elasticsearch.password=

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/config/WSConfiguration.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/config/WSConfiguration.java
@@ -260,4 +260,19 @@ public class WSConfiguration {
 	@Value("${egov.fetch.bill.endpoint}")
 	private String fetchBillEndPoint;
 	
+	@Value("${elasticsearch.host}")
+	private String elasticsearchHost;
+	
+	@Value("${elasticsearch.search.endpoint}")
+	private String elasticsearchSearchEndpoint;
+	
+	@Value("${elasticsearch.index.name}")
+	private String elasticsearchIndexName;
+	
+	@Value("${elasticsearch.username:}")
+	private String elasticsearchUsername;
+
+	@Value("${elasticsearch.password:}")
+	private String elasticsearchPassword;
+	
 }

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/constants/WCConstants.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/constants/WCConstants.java
@@ -32,6 +32,8 @@ public class WCConstants {
 
 	public static final String MDMS_WC_CONNECTION_TYPE = "connectionType";
 
+	 public static final String ES_DATA_PATH = "$..Data";
+	
 	public static final String MDMS_WC_WATER_SOURCE = "waterSource";
 
 	public static final String INVALID_CONNECTION_CATEGORY = "Invalid Connection Category";

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/EditWorkFlowNotificationConsumer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/EditWorkFlowNotificationConsumer.java
@@ -45,7 +45,8 @@ public class EditWorkFlowNotificationConsumer {
 	 * @param record Received Topic Record
 	 * @param topic Name of the Topic
 	 */
-	@KafkaListener(topics = { "${ws.editnotification.topic}"})
+	@KafkaListener(topics = { "${ws.editnotification.topic}"},
+			concurrency = "${kafka.consumer.config.concurrency.count}")
 	public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 		try {
 			WaterConnectionRequest waterConnectionRequest = mapper.convertValue(record, WaterConnectionRequest.class);

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/FileStoreIdsConsumer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/FileStoreIdsConsumer.java
@@ -30,7 +30,8 @@ public class FileStoreIdsConsumer {
 	 * @param record Received Topic Record in HashMap format
 	 * @param topic Name of the Topic
 	 */
-	@KafkaListener(topics = { "${ws.consume.filestoreids.topic}" })
+	@KafkaListener(topics = { "${ws.consume.filestoreids.topic}" },
+			concurrency = "${kafka.consumer.config.concurrency.count}")
 	public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 		try {
 			WaterConnectionRequest waterConnectionRequest = mapper.convertValue(record, WaterConnectionRequest.class);

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/MeterReadingConsumer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/MeterReadingConsumer.java
@@ -32,7 +32,8 @@ public class MeterReadingConsumer {
 	 * @param record
 	 * @param topic
 	 */
-	@KafkaListener(topics = { "${ws.meterreading.create.topic}" })
+	@KafkaListener(topics = { "${ws.meterreading.create.topic}" },
+			concurrency = "${kafka.consumer.config.concurrency.count}")
 	public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 		try {
 			log.info("Received request to add Meter Reading on topic - " + topic);

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/ReceiptConsumer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/ReceiptConsumer.java
@@ -12,7 +12,8 @@ public class ReceiptConsumer {
 	@Autowired
 	private PaymentUpdateService paymentUpdateService;
 	
-	@KafkaListener(topics = {"${kafka.topics.receipt.create}"})
+	@KafkaListener(topics = {"${kafka.topics.receipt.create}"},
+			concurrency = "${kafka.consumer.config.concurrency.count}")
     public void listenPayments(final HashMap<String, Object> record) {
         paymentUpdateService.process(record);
     }

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/WorkflowNotificationConsumer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/consumer/WorkflowNotificationConsumer.java
@@ -49,7 +49,8 @@ public class WorkflowNotificationConsumer {
 	 * @param record
 	 * @param topic
 	 */
-	@KafkaListener(topics = { "${egov.waterservice.createwaterconnection.topic}" ,"${egov.waterservice.updatewaterconnection.topic}", "${egov.waterservice.updatewaterconnection.workflow.topic}"})
+	@KafkaListener(topics = { "${egov.waterservice.createwaterconnection.topic}" ,"${egov.waterservice.updatewaterconnection.topic}", "${egov.waterservice.updatewaterconnection.workflow.topic}"},
+			concurrency = "${kafka.consumer.config.concurrency.count}")
 	public void listen(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 		log.info("Record received in update Water connectuion is"+ record);
 		try {

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/producer/WaterConnectionProducer.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/producer/WaterConnectionProducer.java
@@ -13,4 +13,7 @@ public class WaterConnectionProducer {
 	public void push(String topic, Object value) {
 		kafkaTemplate.send(topic, value);
 	}
+	public void push(String topic, String key,  Object value) {
+		kafkaTemplate.send(topic, key, value);
+	}
 }

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/ElasticSearchRepository.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/ElasticSearchRepository.java
@@ -1,0 +1,88 @@
+package org.egov.waterconnection.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.egov.tracer.model.CustomException;
+import org.egov.waterconnection.config.WSConfiguration;
+import org.egov.waterconnection.repository.builder.WSFuzzySearchQueryBuilder;
+import org.egov.waterconnection.web.models.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+public class ElasticSearchRepository {
+
+    private WSConfiguration config;
+
+    private WSFuzzySearchQueryBuilder queryBuilder;
+
+    private RestTemplate restTemplate;
+
+    private ObjectMapper mapper;
+
+    @Autowired
+    public ElasticSearchRepository(WSConfiguration config, WSFuzzySearchQueryBuilder queryBuilder, 
+                                   RestTemplate restTemplate, ObjectMapper mapper) {
+        this.config = config;
+        this.queryBuilder = queryBuilder;
+        this.restTemplate = restTemplate;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Searches records from elasticsearch based on the fuzzy search criteria for Water Connections
+     *
+     * @param criteria WaterConnection search criteria
+     * @return Object (ElasticSearch Response Body)
+     */
+    public Object fuzzySearchForConnections(SearchCriteria criteria) {
+
+        String url = getESURL();
+
+        // Generates the JSON query string for ES
+        String searchQuery = queryBuilder.getFuzzySearchQuery(criteria);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (config.getElasticsearchUsername() != null && !config.getElasticsearchUsername().isEmpty() &&
+            config.getElasticsearchPassword() != null && !config.getElasticsearchPassword().isEmpty()) {
+            headers.setBasicAuth(config.getElasticsearchUsername(), config.getElasticsearchPassword());
+        }
+        HttpEntity<String> requestEntity = new HttpEntity<>(searchQuery, headers);
+
+        log.info("ES Search URL: {} | Request Body: {}", url, searchQuery);
+
+        ResponseEntity<Object> response = null;
+        try {
+            response = restTemplate.postForEntity(url, requestEntity, Object.class);
+        } catch (Exception e) {
+            log.error("Error occurred while fetching data from ElasticSearch", e);
+            throw new CustomException("ES_ERROR", "Failed to fetch data from ES for Water Connections");
+        }
+
+        return response != null ? response.getBody() : null;
+    }
+
+    /**
+     * Generates elasticsearch search url from water-service application properties
+     * Uses config to build: http://host:port/index-name/_search
+     *
+     * @return Full ES search URL
+     */
+    private String getESURL() {
+
+        StringBuilder builder = new StringBuilder(config.getElasticsearchHost());
+        
+        // Ensure your WSConfiguration has getEsWSIndex() returning the correct water index
+        builder.append(config.getElasticsearchIndexName());
+        builder.append(config.getElasticsearchSearchEndpoint());
+
+        return builder.toString();
+    }
+}

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/WaterDaoImpl.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/WaterDaoImpl.java
@@ -8,12 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.format.DateTimeFormatter;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.threeten.bp.Instant;
+
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.Role;
 import org.egov.common.contract.request.User;
@@ -30,8 +25,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.stereotype.Repository;
+import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDate;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.format.DateTimeFormatter;
 
 import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Slf4j
 @Repository
@@ -72,7 +73,8 @@ public class WaterDaoImpl implements WaterDao {
 
 	@Override
 	public void saveWaterConnection(WaterConnectionRequest waterConnectionRequest) {
-		waterConnectionProducer.push(createWaterConnection, waterConnectionRequest);
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+		waterConnectionProducer.push(createWaterConnection, key, waterConnectionRequest);
 	}
 
 	@Override
@@ -125,6 +127,7 @@ public class WaterDaoImpl implements WaterDao {
 	public void updateWaterConnection(WaterConnectionRequest waterConnectionRequest, boolean isStateUpdatable) {
 		String reqAction = waterConnectionRequest.getWaterConnection().getProcessInstance().getAction();
 		
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
 		if (isStateUpdatable) 
 		{
 			if (WCConstants.EXECUTE_DISCONNECTION.equalsIgnoreCase(reqAction)) 
@@ -137,16 +140,16 @@ public class WaterDaoImpl implements WaterDao {
 			else if(waterConnectionRequest.getWaterConnection().isIsworkflowdisabled())
 			{
 			// For meter number and rest details addition before payment (02-08-2024)
-				waterConnectionProducer.push(updateWaterConnection, waterConnectionRequest);
+				waterConnectionProducer.push(updateWaterConnection, key, waterConnectionRequest);
 			
 			}
 			else
-				waterConnectionProducer.push(updateWaterConnection, waterConnectionRequest);
+				waterConnectionProducer.push(updateWaterConnection, key, waterConnectionRequest);
 		} 
 		
 		
 		else {
-			waterConnectionProducer.push(wsConfiguration.getWorkFlowUpdateTopic(), waterConnectionRequest);
+			waterConnectionProducer.push(wsConfiguration.getWorkFlowUpdateTopic(), key, waterConnectionRequest);
 		}
 	}
 	
@@ -157,7 +160,8 @@ public class WaterDaoImpl implements WaterDao {
 	 */
 	public void postForMeterReading(WaterConnectionRequest waterConnectionRequest) {
 		log.info("Posting request to kafka topic - " + wsConfiguration.getCreateMeterReading());
-		waterConnectionProducer.push(wsConfiguration.getCreateMeterReading(), waterConnectionRequest);
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+		waterConnectionProducer.push(wsConfiguration.getCreateMeterReading(), key , waterConnectionRequest);
 	}
 
 	/**
@@ -168,7 +172,8 @@ public class WaterDaoImpl implements WaterDao {
 	public void pushForEditNotification(WaterConnectionRequest waterConnectionRequest, boolean isStateUpdatable) {
 		if (!WCConstants.EDIT_NOTIFICATION_STATE
 				.contains(waterConnectionRequest.getWaterConnection().getProcessInstance().getAction())) {
-			waterConnectionProducer.push(wsConfiguration.getEditNotificationTopic(), waterConnectionRequest);
+			String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+			waterConnectionProducer.push(wsConfiguration.getEditNotificationTopic(), key, waterConnectionRequest);
 		}
 	}
 	
@@ -178,7 +183,8 @@ public class WaterDaoImpl implements WaterDao {
 	 * @param waterConnectionRequest
 	 */
 	public void enrichFileStoreIds(WaterConnectionRequest waterConnectionRequest) {
-		waterConnectionProducer.push(wsConfiguration.getFileStoreIdsTopic(), waterConnectionRequest);
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+		waterConnectionProducer.push(wsConfiguration.getFileStoreIdsTopic(), key , waterConnectionRequest);
 	}
 	
 	/**
@@ -187,7 +193,8 @@ public class WaterDaoImpl implements WaterDao {
 	 * @param waterConnectionRequest
 	 */
 	public void saveFileStoreIds(WaterConnectionRequest waterConnectionRequest) {
-		waterConnectionProducer.push(wsConfiguration.getSaveFileStoreIdsTopic(), waterConnectionRequest);
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+		waterConnectionProducer.push(wsConfiguration.getSaveFileStoreIdsTopic(), key , waterConnectionRequest);
 	}
 
 	public Boolean isSearchOpen(User userInfo) {
@@ -247,25 +254,25 @@ public class WaterDaoImpl implements WaterDao {
 			for (WaterConnection waterConnection : waterConnectionList) {
             	convertMeterMakeToString(waterConnection);
             	convertLastMeterDateFormat(waterConnection);
+
             }
 			connectionResponse = WaterConnectionResponse.builder().waterConnection(waterConnectionList)
 					.totalCount(openWaterRowMapper.getFull_count()).build();
 		} else {
 			waterConnectionList = jdbcTemplate.query(query, preparedStatement.toArray(), waterRowMapper);
 			for (WaterConnection waterConnection : waterConnectionList) {
-            	convertMeterMakeToString(waterConnection);
-            	convertLastMeterDateFormat(waterConnection);
-            }
+				convertMeterMakeToString(waterConnection);
+				convertLastMeterDateFormat(waterConnection);
+
+			}
 			connectionResponse = WaterConnectionResponse.builder().waterConnection(waterConnectionList)
 					.totalCount(waterRowMapper.getFull_count()).build();
 		}
 		return connectionResponse;
 	}
 	
-	/* PI-21011
-	Migrate DB data to new ElasticSearch for Water
-	*/
-	
+
+
 	private void convertLastMeterDateFormat(WaterConnection wc) {
 
 	    if (wc.getAdditionalDetails() == null)
@@ -388,7 +395,8 @@ public class WaterDaoImpl implements WaterDao {
 	/* Method to push the encrypted data to the 'update' topic  */
 	@Override
 	public void updateOldWaterConnections(WaterConnectionRequest waterConnectionRequest) {
-		waterConnectionProducer.push(updateOldDataEncTopic, waterConnectionRequest);
+		String key = waterConnectionRequest.getWaterConnection().getConnectionNo();
+		waterConnectionProducer.push(updateOldDataEncTopic, key, waterConnectionRequest);
 	}
 
 	/* Method to find the total count of applications present in dB */
@@ -405,7 +413,8 @@ public class WaterDaoImpl implements WaterDao {
 	/* Method to push the old data encryption status to the 'ws-enc-audit' topic  */
 	@Override
 	public void updateEncryptionStatus(EncryptionCount encryptionCount) {
-		waterConnectionProducer.push(encryptionStatusTopic, encryptionCount);
+		String key = encryptionCount.getId();
+		waterConnectionProducer.push(encryptionStatusTopic, key, encryptionCount);
 	}
 	@Override
 	public List<WaterConnection> getPlainWaterConnectionSearch(SearchCriteria criteria) {
@@ -488,5 +497,6 @@ public class WaterDaoImpl implements WaterDao {
 		// TODO Auto-generated method stub
 		return null;
 	}
+	
 	
 }

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/builder/WSFuzzySearchQueryBuilder.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/repository/builder/WSFuzzySearchQueryBuilder.java
@@ -1,0 +1,161 @@
+package org.egov.waterconnection.repository.builder;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.egov.tracer.model.CustomException;
+import org.egov.waterconnection.config.WSConfiguration;
+import org.egov.waterconnection.web.models.SearchCriteria;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class WSFuzzySearchQueryBuilder {
+
+    private ObjectMapper mapper;
+    private WSConfiguration config;
+
+    @Autowired
+    public WSFuzzySearchQueryBuilder(ObjectMapper mapper, WSConfiguration config) {
+        this.mapper = mapper;
+        this.config = config;
+    }
+
+    private static final String BASE_QUERY = "{\n" +
+            "  \"from\": {{OFFSET}},\n" +
+            "  \"size\": {{LIMIT}},\n" +
+            "  \"sort\": {\n" +
+            "    \"Data.auditDetails.createdTime\": { \"order\": \"desc\" }\n" +
+            "  },\n" +
+            "  \"query\": {}\n" +
+            "}";
+
+    private static final String wildCardQueryTemplate = "{\"query_string\": {\"default_field\": \"{{VAR}}\", \"query\": \"*{{PARAM}}*\"}}";
+    private static final String queryTemplate = "{\"query_string\": {\"default_field\": \"{{VAR}}\", \"query\": \"{{PARAM}}\"}}";
+
+    public String getFuzzySearchQuery(SearchCriteria criteria) {
+        try {
+            String baseQuery = addPagination(criteria);
+            JsonNode node = mapper.readTree(baseQuery);
+            ObjectNode insideMatch = (ObjectNode) node.get("query");
+            List<JsonNode> mustList = new LinkedList<>();
+
+            // 1. Tenant Filter (Data.tenantId)
+            if (criteria.getTenantId() != null) {
+                mustList.add(getInnerNode(criteria.getTenantId(), "Data.tenantId", false));
+            }
+
+            // 2. Owner Name Filter (Checks additionalDetails OR connectionHolders list)
+            if (criteria.getOwnerName() != null) {
+                List<JsonNode> nameShouldClauses = new LinkedList<>();
+                nameShouldClauses.add(getInnerNode(criteria.getOwnerName(), "Data.additionalDetails.ownerName", true));
+                nameShouldClauses.add(getInnerNode(criteria.getOwnerName(), "Data.connectionHolders.name", true));
+
+                Map<String, Object> shouldBool = new HashMap<>();
+                shouldBool.put("should", nameShouldClauses);
+                shouldBool.put("minimum_should_match", 1);
+                
+                mustList.add(mapper.convertValue(new HashMap<String, Object>() {{ put("bool", shouldBool); }}, JsonNode.class));
+            }
+
+            // 3. Consumer / Connection Number (Data.connectionNo)
+            if (!CollectionUtils.isEmpty(criteria.getConnectionNumber())) {
+                for (String connNo : criteria.getConnectionNumber()) {
+                    mustList.add(getInnerNode(connNo, "Data.connectionNo.keyword", false));
+                }
+            }
+
+            // 4. Application Number (Data.applicationNo)
+            if (!CollectionUtils.isEmpty(criteria.getApplicationNumber())) {
+                for (String appNo : criteria.getApplicationNumber()) {
+                    mustList.add(getInnerNode(appNo, "Data.applicationNo.keyword", false));
+                }
+            }
+
+            // 5. Mobile Number (Data.connectionHolders.mobileNumber)
+            if (criteria.getMobileNumber() != null) {
+                mustList.add(getInnerNode(criteria.getMobileNumber(), "Data.connectionHolders.mobileNumber.keyword", false));
+            }
+
+            // 6. Property ID (Data.propertyId)
+            if (criteria.getPropertyId() != null) {
+                mustList.add(getInnerNode(criteria.getPropertyId(), "Data.propertyId.keyword", false));
+            }
+
+            // 7. Locality (Data.additionalDetails.locality)
+            if (criteria.getLocality() != null) {
+                mustList.add(getInnerNode(criteria.getLocality(), "Data.additionalDetails.locality", false));
+            }
+
+            // 8. Application Status (Data.applicationStatus)
+            if (criteria.getStatus() != null) {
+                mustList.add(getInnerNode(criteria.getStatus(), "Data.applicationStatus.keyword", false));
+            }
+
+            // 9. Date Range Filter (Created Time)
+            if (criteria.getFromDate() != null || criteria.getToDate() != null) {
+                Map<String, Object> rangeParams = new HashMap<>();
+                if (criteria.getFromDate() != null) rangeParams.put("gte", criteria.getFromDate());
+                if (criteria.getToDate() != null) rangeParams.put("lte", criteria.getToDate());
+                
+                Map<String, Object> rangeField = new HashMap<>();
+                rangeField.put("Data.auditDetails.createdTime", rangeParams);
+                mustList.add(mapper.convertValue(new HashMap<String, Object>() {{ put("range", rangeField); }}, JsonNode.class));
+            }
+
+            // Final query assembly
+            Map<String, Object> boolMap = new HashMap<>();
+            boolMap.put("must", mustList);
+            insideMatch.set("bool", mapper.convertValue(boolMap, JsonNode.class));
+
+            return mapper.writeValueAsString(node);
+
+        } catch (Exception e) {
+            log.error("ES_QUERY_BUILDER_ERROR", e);
+            throw new CustomException("QUERY_BUILD_ERROR", "Failed to build JSON query for Water Connection fuzzy search");
+        }
+    }
+
+    private JsonNode getInnerNode(String param, String var, boolean isWildCard) throws JsonProcessingException {
+        String template = isWildCard ? wildCardQueryTemplate : queryTemplate;
+        String innerQuery = template.replace("{{PARAM}}", getEscapedString(param));
+        innerQuery = innerQuery.replace("{{VAR}}", var);
+        return mapper.readTree(innerQuery);
+    }
+
+    private String addPagination(SearchCriteria criteria) {
+        Long limit = config.getDefaultLimit().longValue();
+        Long offset = config.getDefaultOffset().longValue();
+
+        if (criteria.getLimit() != null) {
+            limit = Math.min(criteria.getLimit().longValue(), config.getMaxLimit().longValue());
+        }
+        if (criteria.getOffset() != null) {
+            offset = criteria.getOffset().longValue();
+        }
+
+        return BASE_QUERY.replace("{{OFFSET}}", offset.toString())
+                         .replace("{{LIMIT}}", limit.toString());
+    }
+
+    private String getEscapedString(String inputString) {
+        final String[] metaCharacters = {"\\", "/", "^", "$", "{", "}", "[", "]", "(", ")", "*", "+", "?", "|", "<", ">", "-", "&", "%"};
+        for (String character : metaCharacters) {
+            if (inputString.contains(character)) {
+                inputString = inputString.replace(character, "\\\\" + character);
+            }
+        }
+        return inputString;
+    }
+}

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WSFuzzySearchService.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WSFuzzySearchService.java
@@ -1,0 +1,173 @@
+package org.egov.waterconnection.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.tracer.model.CustomException;
+import org.egov.waterconnection.repository.*;
+import org.egov.waterconnection.web.models.WaterConnection;
+import org.egov.waterconnection.web.models.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.egov.waterconnection.constants.WCConstants.*;
+
+@Service
+@Slf4j
+public class WSFuzzySearchService {
+
+    private ElasticSearchRepository elasticSearchRepository;
+    private ObjectMapper mapper;
+    private WaterDaoImpl WaterDaoImpl;
+
+    @Autowired
+    public WSFuzzySearchService(ElasticSearchRepository elasticSearchRepository, ObjectMapper mapper, WaterDaoImpl repository) {
+        this.elasticSearchRepository = elasticSearchRepository;
+        this.mapper = mapper;
+        this.WaterDaoImpl = repository;
+    }
+
+    /**
+     * Executes fuzzy search by coordinating between ES and the Database.
+     * * @param requestInfo Standard eGov request metadata
+     * @param criteria Search parameters (name, connectionNo, etc.)
+     * @return Ordered list of WaterConnections
+     */
+    public List<WaterConnection> getConnections(RequestInfo requestInfo, SearchCriteria criteria) {
+
+        log.info("Initiating fuzzy search with criteria: {}", criteria);
+
+        // 1. Validate that at least one fuzzy field is provided
+        validateFuzzySearchCriteria(criteria);
+
+        // 2. Search ElasticSearch for matching IDs
+        Object esResponse = elasticSearchRepository.fuzzySearchForConnections(criteria);
+
+        // 3. Extract IDs and group by TenantId
+        Map<String, Set<String>> tenantIdToConnectionNos = getTenantIdToConnectionNoMap(esResponse);
+
+        if (CollectionUtils.isEmpty(tenantIdToConnectionNos)) {
+            return new LinkedList<>();
+        }
+
+        List<WaterConnection> connections = new LinkedList<>();
+
+        // 4. Hydrate full connection data from DB
+        for (Map.Entry<String, Set<String>> entry : tenantIdToConnectionNos.entrySet()) {
+            
+            SearchCriteria dbCriteria = SearchCriteria.builder()
+                    .tenantId(entry.getKey())
+                    .connectionNumber(entry.getValue())
+                    .build();
+
+            // Fetching from DB ensures we have the latest owner/connection details
+            connections.addAll(WaterDaoImpl.getWaterConnectionList(dbCriteria, requestInfo));
+        }
+
+        // 5. Restore the order of results based on ElasticSearch relevance score
+        return orderByESScore(connections, esResponse);
+    }
+
+    /**
+     * Re-sorts the DB results to match the ranking (score) provided by ES.
+     */
+    private List<WaterConnection> orderByESScore(List<WaterConnection> connections, Object esResponse) {
+
+        List<WaterConnection> orderedConnections = new LinkedList<>();
+
+        if (!CollectionUtils.isEmpty(connections)) {
+            Map<String, WaterConnection> idToConnectionMap = new LinkedHashMap<>();
+
+            // Map connections by their business identifier (Connection Number)
+            connections.forEach(conn -> idToConnectionMap.put(conn.getConnectionNo(), conn));
+
+            try {
+                List<Map<String, Object>> data = JsonPath.read(esResponse, ES_DATA_PATH);
+
+                if (!CollectionUtils.isEmpty(data)) {
+                    for (Map<String, Object> map : data) {
+                        String connNo = JsonPath.read(map, "$.connectionNo");
+                        if (idToConnectionMap.containsKey(connNo)) {
+                            orderedConnections.add(idToConnectionMap.get(connNo));
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to parse ES response during ordering phase", e);
+                throw new CustomException("PARSING_ERROR", "Failed to extract connectionNos from ES response");
+            }
+        }
+
+        return orderedConnections;
+    }
+
+    /**
+     * Parses the ES response to create a map of TenantId to ConnectionNumbers.
+     */
+    private Map<String, Set<String>> getTenantIdToConnectionNoMap(Object esResponse) {
+
+        Map<String, Set<String>> tenantIdToConnectionNos = new LinkedHashMap<>();
+
+        try {
+            List<Map<String, Object>> data = JsonPath.read(esResponse, ES_DATA_PATH);
+
+            if (!CollectionUtils.isEmpty(data)) {
+                for (Map<String, Object> map : data) {
+                    String tenantId = JsonPath.read(map, "$.tenantId");
+                    String connectionNo = JsonPath.read(map, "$.connectionNo");
+
+                    // Check for null and empty string to avoid downstream Hydration errors
+                    if (tenantId != null && connectionNo != null && !connectionNo.trim().isEmpty()) {
+                        tenantIdToConnectionNos
+                            .computeIfAbsent(tenantId, k -> new HashSet<>())
+                            .add(connectionNo);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to parse ES response during ID extraction", e);
+            throw new CustomException("PARSING_ERROR", "Failed to extract connection data from ES response");
+        }
+
+        return tenantIdToConnectionNos;
+    }
+
+    /**
+     * Ensures search parameters are valid for a fuzzy search.
+     */
+    private void validateFuzzySearchCriteria(SearchCriteria criteria) {
+
+        // 1. Absolute Mandatory: tenantId must be present for ALL searches
+        if (criteria.getTenantId() == null || criteria.getTenantId().trim().isEmpty()) {
+            throw new CustomException("EG_WS_SEARCH_TENANTID_MANDATORY", "TenantId is mandatory for all search operations.");
+        }
+
+        // 2. Dependency: If searching by Name, Locality is also mandatory
+        if (criteria.getOwnerName() != null && criteria.getLocality() == null) {
+            throw new CustomException("EG_WS_SEARCH_LOCALITY_MANDATORY", "Locality is mandatory when searching by Owner Name.");
+        }
+
+        // 3. Minimum Criteria: At least one fuzzy parameter must exist
+        if (criteria.getConnectionNumber() == null && 
+            criteria.getOldConnectionNumber() == null && 
+            criteria.getOwnerName() == null && 
+            criteria.getDoorNo() == null &&
+            criteria.getLocality()==null
+            ) {
+            
+            throw new CustomException("INVALID_SEARCH_CRITERIA", "Please provide at least one search parameter (Connection No, Name, or Door No).");
+        }
+    }
+}

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WaterServiceImpl.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WaterServiceImpl.java
@@ -71,6 +71,9 @@ public class WaterServiceImpl implements WaterService {
 
 	@Autowired
 	private WaterServicesUtil waterServiceUtil;
+	
+	@Autowired
+	private WSFuzzySearchService WSFuzzySearchService;
 
 	@Autowired
 	private CalculationService calculationService;
@@ -297,7 +300,11 @@ public class WaterServiceImpl implements WaterService {
 	 */
 	public List<WaterConnection> search(SearchCriteria criteria, RequestInfo requestInfo) {
 		List<WaterConnection> waterConnectionList;
-		waterConnectionList = getWaterConnectionsList(criteria, requestInfo);
+		
+		if(criteria.getOwnerName() != null || criteria.getDoorNo() != null ||criteria.getLocality() != null)
+            waterConnectionList = WSFuzzySearchService.getConnections(requestInfo,criteria);
+        else
+            waterConnectionList = getWaterConnectionsList(criteria, requestInfo);
 		log.info("Water Connection List Inside Search API call ::" + waterConnectionList);
 		log.info("Search Criteria ::" + criteria);
 		if (!StringUtils.isEmpty(criteria.getSearchType())

--- a/municipal-services/ws-services/src/main/resources/application.properties
+++ b/municipal-services/ws-services/src/main/resources/application.properties
@@ -191,3 +191,15 @@ egov.waterservice.update.oldData.topic=update-ws-encryption
 eodb.token.url=https://pbindustries.gov.in/testportalnode/api/iptoken/gettoken
 eodb.update.url=https://pbindustries.gov.in/testportalnode/api/lg/UpdateStatus
 eodb.integration.key=UAT_LG
+
+kafka.consumer.config.concurrency.count=3
+
+#-------Elasticsearch Configurations----------------#
+elasticsearch.host=http://localhost:9200/
+elasticsearch.search.endpoint=/_search
+
+elasticsearch.index.name=water-services
+
+# optional basic authentication credentials for Elasticsearch:
+elasticsearch.username=
+elasticsearch.password=


### PR DESCRIPTION
Introduce Elasticsearch fuzzy-search support for water and sewerage services: add ElasticSearchRepository, query builders (WSFuzzySearchQueryBuilder / SWFuzzySearchQueryBuilder) and fuzzy search services (WSFuzzySearchService / SWFuzzySearchService) to build ES queries, call ES, extract IDs, hydrate DB records and order results by ES relevance. Update SW/WS configuration and application.properties to include ES host/index/search endpoint and optional basic-auth credentials; add ES_DATA_PATH constants. Fix SewarageController to use RequestInfo and route fuzzy searches through SWFuzzySearchService. Enhance Kafka usage: add WaterConnectionProducer.push overload to include key, update WaterDaoImpl to publish messages with key, and add concurrency setting to several @KafkaListener annotations (driven by kafka.consumer.config.concurrency.count). Also include various minor refactors, pagination/escaping in query builders, and improved error handling for ES interactions.