### PR TITLE
Add optional Elasticsearch basic auth support

### DIFF
--- a/municipal-services/property-services/src/main/java/org/egov/pt/config/PropertyConfiguration.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/config/PropertyConfiguration.java
@@ -92,6 +92,11 @@ public class PropertyConfiguration {
 
     //IDGEN config
     
+    @Value("${elasticsearch.username:}")
+    private String elasticsearchUsername;
+
+    @Value("${elasticsearch.password:}")
+    private String elasticsearchPassword;
     @Value("${egov.idgen.host}")
     private String idGenHost;
 

--- a/municipal-services/property-services/src/main/java/org/egov/pt/repository/ElasticSearchRepository.java
+++ b/municipal-services/property-services/src/main/java/org/egov/pt/repository/ElasticSearchRepository.java
@@ -78,6 +78,10 @@ public class ElasticSearchRepository {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+        if (config.getElasticsearchUsername() != null && !config.getElasticsearchUsername().isEmpty() &&
+                config.getElasticsearchPassword() != null && !config.getElasticsearchPassword().isEmpty()) {
+                headers.setBasicAuth(config.getElasticsearchUsername(), config.getElasticsearchPassword());
+            }
         HttpEntity<String> requestEntity = new HttpEntity<>(searchQuery, headers);
         log.info("Url"+url+"reuest"+requestEntity);
         ResponseEntity response = null;

--- a/municipal-services/property-services/src/main/resources/application.properties
+++ b/municipal-services/property-services/src/main/resources/application.properties
@@ -216,6 +216,8 @@ security.headers.frame=false
 #Elastic search properties
 elasticsearch.host=http://localhost:9200/
 elasticsearch.search.endpoint=/_search
+elasticsearch.username=
+elasticsearch.password=
 
 #-----Value of property.es.index to be replaced with "pt-fuzzy-search-index" when Privacy is enabled------#
 property.es.index=property-services


### PR DESCRIPTION
Read elasticsearch.username and elasticsearch.password from configuration and conditionally set the HTTP Basic Auth header when both are present. Adds corresponding @Value fields in PropertyConfiguration and checks them in ElasticSearchRepository; also adds the properties to application.properties.