### PR TITLE
Use UAT Kafka consumer group

### DIFF
--- a/municipal-services/firenoc-services/src/kafka/consumer.js
+++ b/municipal-services/firenoc-services/src/kafka/consumer.js
@@ -20,7 +20,7 @@ initializeProducer().then((p) => {
 // Using your dynamic offset variable
 var options = {
   kafkaHost: envVariables.KAFKA_BROKER_HOST,
-  groupId: "firenoc-consumer-grp",
+  groupId: "firenoc-consumer-grp-uat",
   autoCommit: true,
   autoCommitIntervalMs: 5000,
   sessionTimeout: 15000,


### PR DESCRIPTION
Update Kafka consumer groupId in municipal-services/firenoc-services/src/kafka/consumer.js from "firenoc-consumer-grp" to "firenoc-consumer-grp-uat" so the consumer is scoped to the UAT environment and avoids clashing with other environment consumer groups.