### PR TITLE
Use 'SYSTEM' as system role code

### DIFF
--- a/municipal-services/firenoc-services/src/utils/index.js
+++ b/municipal-services/firenoc-services/src/utils/index.js
@@ -91,7 +91,7 @@ export const createWorkFlow = async body => {
   });
   
   var systemPaymentRole = {
-    code: "SYSTEM_PAYMENT",
+    code: "SYSTEM",
     tenantId: body.FireNOCs[0].tenantId
   };
   body.RequestInfo.userInfo.roles.push(systemPaymentRole);


### PR DESCRIPTION
Update createWorkFlow to set the systemPaymentRole.code from "SYSTEM_PAYMENT" to "SYSTEM" so the role pushed into body.RequestInfo.userInfo.roles uses the standardized "SYSTEM" code.