### PR TITLE
PT assessment job schduler not picking up all configured tenants

### DIFF
--- a/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/repository/AssessmentRepository.java
+++ b/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/repository/AssessmentRepository.java
@@ -147,12 +147,12 @@ public class AssessmentRepository {
 		return assessments;
 	}
 
-	public Integer getActivePropertyCount(CreateAssessmentRequest request) {
+	public Long getActivePropertyCount(CreateAssessmentRequest request) {
 		StringBuilder query = new StringBuilder(PROPERTY_COUNT_ACTIVE);
 		query.append(" and prop.tenantid=?");
 		List<Object> preparedStmtList = new ArrayList<>();
 		preparedStmtList.add(request.getTenantId());
-		Integer count = jdbcTemplate.queryForObject(query.toString(), preparedStmtList.toArray(), Integer.class);
+		Long count = jdbcTemplate.queryForObject(query.toString(), preparedStmtList.toArray(), Long.class);
 		return count;
 
 	}

--- a/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/service/AssessmentService.java
+++ b/municipal-services/pt-calculator-v2/src/main/java/org/egov/pt/calculator/service/AssessmentService.java
@@ -211,7 +211,7 @@ public class AssessmentService {
 			assessmentRequest.setIsRented(configData.get(CalculatorConstants.IS_RENTED) == null ? true
 					: (Boolean) configData.get(CalculatorConstants.IS_RENTED));
 
-			int count = repository.getActivePropertyCount(assessmentRequest);
+			Long count = repository.getActivePropertyCount(assessmentRequest);
 			
 		
 			if (assessmentRequest.getLimit() != null && assessmentRequest.getLimit() > configs.getMaxSearchLimit())
@@ -275,7 +275,10 @@ public class AssessmentService {
 
 				}
 				
-				offset = limit +offset;
+				offset += limit;
+			}
+			if(scheduledTenants.size() > 1) {
+				assessmentRequest.setOffset(configs.getDefaultOffset());
 			}
 		}
 		return assessedProperties;


### PR DESCRIPTION
Auto Assessment job schduler for PT is not picking all congifured tenants (json objects) during assessment being run through schduler. it picks only one or two objects which are configured. Here to mention that assessments are configured in mdms in "https://github.com/pmidc-digit/punjab-mdms-data/blob/PROD_V2/data/pb/tenant/assessmentconfig.json" . assessment job should pick all the objects having "enabled" attribute as "true".