### PR TITLE
Add MDMS city resolution and input trimming

### DIFF
--- a/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/service/DataExchangeService.java
+++ b/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/service/DataExchangeService.java
@@ -111,6 +111,7 @@ public class DataExchangeService {
             }
             
             RequestInfoWrapper requestWrapper = prepareRequestInfo();
+            resolveCityFromMdms(searchCriteria, requestWrapper);
             String docType = searchCriteria.getDocType();
 
             log.info("Processing DigiLocker Request for DocType: {}", docType);
@@ -294,12 +295,12 @@ private String handleWaterSewerage(SearchCriteria searchCriteria, boolean isUriR
                   .append("?searchType=CONNECTION")
                   .append("&tenantId=").append(TENANT_PREFIX).append(sc.getCity());
                   
-        if (sc.getMobile() != null && !sc.getMobile().isEmpty()) {
-            urlBuilder.append("&mobileNumber=").append(sc.getMobile());
+        if (sc.getMobile() != null && !sc.getMobile().trim().isEmpty()) {
+            urlBuilder.append("&mobileNumber=").append(sc.getMobile().trim());
         }
         
-        if (sc.getPropertyId() != null && !sc.getPropertyId().isEmpty()) {
-            urlBuilder.append("&connectionNumber=").append(sc.getPropertyId());
+        if (sc.getPropertyId() != null && !sc.getPropertyId().trim().isEmpty()) {
+            urlBuilder.append("&connectionNumber=").append(sc.getPropertyId().trim());
         }
 
         Map<String, Object> requestBody = new HashMap<>();
@@ -664,5 +665,98 @@ private String handleWaterSewerage(SearchCriteria searchCriteria, boolean isUriR
         cert.setCertificateData(data);
 
         return cert;
+    }
+
+    private void resolveCityFromMdms(SearchCriteria searchCriteria, RequestInfoWrapper requestWrapper) {
+        if (searchCriteria.getCity() != null && !searchCriteria.getCity().trim().isEmpty()) {
+            log.info("City '{}' is already present in request criteria, skipping MDMS level lookup", searchCriteria.getCity());
+            return;
+        }
+
+        String level1 = searchCriteria.getLevel1();
+        String level2 = searchCriteria.getLevel2();
+
+        if (level1 == null || level1.trim().isEmpty() || level2 == null || level2.trim().isEmpty()) {
+            return;
+        }
+
+        try {
+            log.info("Resolving city from MDMS using level1='{}', level2='{}'", level1, level2);
+
+            Map<String, Object> masterDetail = new HashMap<>();
+            masterDetail.put("name", "tenants");
+            masterDetail.put("filter", String.format("[?(@.ulbCode=='%s' && @.districtCode=='%s')]", level2, level1));
+
+            Map<String, Object> moduleDetail = new HashMap<>();
+            moduleDetail.put("moduleName", "tenant");
+            moduleDetail.put("masterDetails", Collections.singletonList(masterDetail));
+
+            Map<String, Object> mdmsCriteria = new HashMap<>();
+            mdmsCriteria.put("tenantId", "pb");
+            mdmsCriteria.put("moduleDetails", Collections.singletonList(moduleDetail));
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("RequestInfo", requestWrapper.getRequestInfo());
+            requestBody.put("MdmsCriteria", mdmsCriteria);
+
+            String mdmsUrl = configurations.getMdmsHost() + configurations.getMdmsEndpoint();
+            JsonNode mdmsRes = restTemplate.postForObject(mdmsUrl, requestBody, JsonNode.class);
+
+            if (mdmsRes != null && mdmsRes.has("MdmsRes")) {
+                JsonNode tenantsNode = mdmsRes.path("MdmsRes").path("tenant").path("tenants");
+                if (tenantsNode.isArray() && tenantsNode.size() > 0) {
+                    JsonNode tenantObj = tenantsNode.get(0);
+                    String tenantCode = tenantObj.path("code").asText("");
+                    if (!tenantCode.isEmpty()) {
+                        String city = tenantCode.startsWith("pb.") ? tenantCode.substring(3) : tenantCode;
+                        searchCriteria.setCity(city);
+                        log.info("Successfully resolved city '{}' from MDMS (tenantCode: {})", city, tenantCode);
+                        return;
+                    }
+                }
+            }
+
+            // Fallback: Retry without MDMS filter if filter produced no matches
+            masterDetail.remove("filter");
+            mdmsRes = restTemplate.postForObject(mdmsUrl, requestBody, JsonNode.class);
+
+            if (mdmsRes != null && mdmsRes.has("MdmsRes")) {
+                JsonNode tenantsNode = mdmsRes.path("MdmsRes").path("tenant").path("tenants");
+                if (tenantsNode.isArray()) {
+                    for (JsonNode t : tenantsNode) {
+                        String tenantCode = t.path("code").asText("");
+                        
+                        String districtCode = t.path("districtCode").asText("");
+                        if (districtCode.isEmpty()) {
+                            districtCode = t.path("city").path("districtCode").asText("");
+                        }
+                        
+                        String ulbCode = t.path("ulbCode").asText("");
+                        if (ulbCode.isEmpty()) {
+                            ulbCode = t.path("city").path("ulbCode").asText("");
+                            if (ulbCode.isEmpty()) {
+                                ulbCode = t.path("city").path("code").asText("");
+                            }
+                        }
+
+                        boolean matchesDistrict = districtCode.equalsIgnoreCase(level1)
+                                || tenantCode.toLowerCase().contains(level1.toLowerCase());
+                        boolean matchesUlb = ulbCode.equalsIgnoreCase(level2)
+                                || tenantCode.equalsIgnoreCase(level2)
+                                || tenantCode.equalsIgnoreCase("pb." + level2)
+                                || tenantCode.toLowerCase().endsWith("." + level2.toLowerCase());
+
+                        if (matchesDistrict && matchesUlb) {
+                            String city = tenantCode.startsWith("pb.") ? tenantCode.substring(3) : tenantCode;
+                            searchCriteria.setCity(city);
+                            log.info("Successfully resolved city '{}' via fallback match from MDMS (tenantCode: {})", city, tenantCode);
+                            return;
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to resolve city from MDMS for level1='{}', level2='{}': ", level1, level2, e);
+        }
     }
 }

--- a/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/util/XMLRequestParser.java
+++ b/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/util/XMLRequestParser.java
@@ -27,19 +27,21 @@ public class XMLRequestParser {
         
         // FIX: Check for both propertyId and consumerCode
         String idToSearch = request.getDocDetails().getPropertyId();
-        if (idToSearch == null || idToSearch.isEmpty()) {
+        if (idToSearch == null || idToSearch.trim().isEmpty()) {
             idToSearch = request.getDocDetails().getConsumerCode();
         }
 
         SearchCriteria criteria = SearchCriteria.builder()
-            .propertyId(idToSearch) // Pass the resolved ID here
-            .city(request.getDocDetails().getCity())
-            .connType(request.getDocDetails().getConnType())
-            .origin(origin)
-            .txn(txn)
-            .docType(request.getDocDetails().getDocType())
-            .payerName(request.getDocDetails().getFullName())
-            .mobile(request.getDocDetails().getMobile())
+            .propertyId(trim(idToSearch))
+            .city(trim(request.getDocDetails().getCity()))
+            .connType(trim(request.getDocDetails().getConnType()))
+            .level1(trim(request.getDocDetails().getLevel1()))
+            .level2(trim(request.getDocDetails().getLevel2()))
+            .origin(trim(origin))
+            .txn(trim(txn))
+            .docType(trim(request.getDocDetails().getDocType()))
+            .payerName(trim(request.getDocDetails().getFullName()))
+            .mobile(trim(request.getDocDetails().getMobile()))
             .build();
             
         return criteria;
@@ -51,16 +53,20 @@ public class XMLRequestParser {
         PullDocRequest request = (PullDocRequest) xstream.fromXML(xmlBody);
         String txn = extractTxn(xmlBody, request.getTxn());
         SearchCriteria criteria = new SearchCriteria();
-        criteria.setURI(request.getDocDetails().getURI());
-        criteria.setOrigin(origin);
-        criteria.setTxn(txn);
+        criteria.setURI(trim(request.getDocDetails().getURI()));
+        criteria.setOrigin(trim(origin));
+        criteria.setTxn(trim(txn));
         return criteria;
     }
 
     private String extractTxn(String xmlBody, String txnAttr) {
-        if (txnAttr != null) return txnAttr;
+        if (txnAttr != null) return txnAttr.trim();
         // Fallback regex split from original
-        return xmlBody.split("txn=\"")[1].split("\"")[0];
+        return xmlBody.split("txn=\"")[1].split("\"")[0].trim();
+    }
+
+    private String trim(String val) {
+        return val != null ? val.trim() : null;
     }
 
     private XStream configureXStream() {

--- a/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/web/models/DocDetailsRequest.java
+++ b/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/web/models/DocDetailsRequest.java
@@ -36,7 +36,12 @@ public class DocDetailsRequest {
     private String connType;
     
     
+    @XStreamAlias("level1")
+    private String level1;
 
+    @XStreamAlias("level2")
+    private String level2;
+    
     @XStreamAlias("City")
     private String city;
 
@@ -118,5 +123,21 @@ public class DocDetailsRequest {
 
     public void setCity(String city) {
         this.city = city;
+    }
+
+    public String getLevel1() {
+        return level1;
+    }
+
+    public void setLevel1(String level1) {
+        this.level1 = level1;
+    }
+
+    public String getLevel2() {
+        return level2;
+    }
+
+    public void setLevel2(String level2) {
+        this.level2 = level2;
     }
 }

--- a/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/web/models/SearchCriteria.java
+++ b/core-services/egov-pb-digilocker/src/main/java/org/egov/dx/web/models/SearchCriteria.java
@@ -34,4 +34,8 @@ public class SearchCriteria {
     
     private String mobile;
 
+    private String level1;
+
+    private String level2;
+
 }


### PR DESCRIPTION
Support hierarchical city resolution using level1 and level2 parameters by querying MDMS when city is not directly provided. Added level1 and level2 fields to DocDetailsRequest and SearchCriteria models. Improved robustness by trimming whitespace from all string inputs in XMLRequestParser and DataExchangeService to handle malformed input data.