### PR TITLE
optimised plain search api

### DIFF
--- a/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/repository/ScorecardSurveyRepository.java
+++ b/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/repository/ScorecardSurveyRepository.java
@@ -216,6 +216,40 @@ public class ScorecardSurveyRepository {
         });
     }
 
+    // Paginated survey responses for plainsearch
+    public List<SurveyResponseNew> getSurveyResponsesByTenantPaginated(String tenantId, Integer offset, Integer limit) {
+        int l = (limit != null && limit > 0) ? limit : 50;
+        int o = (offset != null && offset >= 0) ? offset : 0;
+        String query = "SELECT * FROM eg_ss_survey_response WHERE tenantid = ? ORDER BY createdtime DESC LIMIT ? OFFSET ?";
+        return jdbcTemplate.query(query, new Object[]{tenantId, l, o}, new SurveyResponseRowMapper());
+    }
+
+    // Fetch answers for a batch of survey response UUIDs
+    public List<AnswerNew> getAnswersForSurveyResponses(List<String> surveyResponseUuids) {
+        if (org.springframework.util.CollectionUtils.isEmpty(surveyResponseUuids)) {
+            return new ArrayList<>();
+        }
+        String placeholders = surveyResponseUuids.stream().map(u -> "?").collect(Collectors.joining(","));
+        String query =
+                "SELECT ans.uuid, ans.sectionuuid, ans.questionuuid, ans.comments, " +
+                        "q.questionstatement, sec.title AS section_title, " +
+                        "qw.weightage AS question_weightage, " +
+                        "sec.weightage AS section_weightage, " +
+                        "ad.uuid AS answer_detail_uuid, ad.answertype AS answer_detail_type, " +
+                        "ad.answercontent AS answer_detail_content, ad.weightage AS answer_detail_weightage, " +
+                        "ans.createdby, ans.lastmodifiedby, ans.createdtime, ans.lastmodifiedtime, " +
+                        "sr.citizenid AS survey_citizen_id, ans.surveyresponseuuid AS surveyresponseuuid " +
+                        "FROM eg_ss_answer ans " +
+                        "JOIN eg_ss_answer_detail ad ON ans.uuid = ad.answeruuid " +
+                        "JOIN eg_ss_question q ON ans.questionuuid = q.uuid " +
+                        "LEFT JOIN eg_ss_question_weightage qw ON ans.questionuuid = qw.questionuuid AND ans.sectionuuid = qw.sectionuuid " +
+                        "LEFT JOIN eg_ss_survey_section sec ON ans.sectionuuid = sec.uuid " +
+                        "JOIN eg_ss_survey_response sr ON ans.surveyresponseuuid = sr.uuid " +
+                        "WHERE ans.surveyresponseuuid IN (" + placeholders + ")";
+
+        return jdbcTemplate.query(query, surveyResponseUuids.toArray(), new AnswerRowMapper());
+    }
+
 //    public List<AnswerNew> getAnswersForSurvey(String surveyUuid, String tenantId) {
 //        String query =
 //                "SELECT " +

--- a/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/repository/rowmapper/AnswerRowMapper.java
+++ b/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/repository/rowmapper/AnswerRowMapper.java
@@ -51,6 +51,20 @@ public class AnswerRowMapper implements ResultSetExtractor<List<AnswerNew>> {
                     } catch (SQLException ignored) {
                         // Column section_title might not be present in all queries using this mapper
                     }
+                    try {
+                        String srUuid = rs.getString("surveyresponseuuid");
+                        if (srUuid != null) {
+                            answerNew.setSurveyResponseUuid(srUuid);
+                        }
+                    } catch (SQLException ignored) {
+                    }
+                    try {
+                        String citizenId = rs.getString("survey_citizen_id");
+                        if (citizenId != null) {
+                            answerNew.setCitizenId(citizenId);
+                        }
+                    } catch (SQLException ignored) {
+                    }
                     return answerNew;
                 } catch (SQLException e) {
                     throw new RuntimeException("Error while extracting answer data", e);

--- a/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/service/ScorecardSurveyService.java
+++ b/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/service/ScorecardSurveyService.java
@@ -467,73 +467,115 @@ public class ScorecardSurveyService {
 //    }
 
     public PlainSearchResponse getAnswersForPlainSearch(AnswerFetchCriteria criteria, RequestInfo requestInfo) {
-        List<String> surveyUuids = surveyRepository.getSurveyUuidsByTenant(criteria.getTenantId());
+        Integer offset = (criteria.getOffset() != null && criteria.getOffset() >= 0) ? criteria.getOffset() : 0;
+        Integer limit = (criteria.getLimit() != null && criteria.getLimit() > 0) ? criteria.getLimit() : 50;
+
+        // 1. Fetch paginated survey responses from DB (e.g., 50 at a time)
+        List<SurveyResponseNew> surveyResponses = surveyRepository.getSurveyResponsesByTenantPaginated(criteria.getTenantId(), offset, limit);
+        if (CollectionUtils.isEmpty(surveyResponses)) {
+            return PlainSearchResponse.builder()
+                    .surveyResponses(new ArrayList<>())
+                    .build();
+        }
+
+        List<String> surveyResponseUuids = surveyResponses.stream()
+                .map(SurveyResponseNew::getUuid)
+                .collect(Collectors.toList());
+
+        // 2. Fetch answers for this paginated batch of survey responses
+        List<AnswerNew> answers = surveyRepository.getAnswersForSurveyResponses(surveyResponseUuids);
+
+        for (AnswerNew answer : answers) {
+            Integer qWeight = surveyRepository.getQuestionWeightage(answer.getQuestionUuid(), answer.getSectionUuid());
+            Integer sWeight = surveyRepository.getSectionWeightage(answer.getSectionUuid());
+            answer.setQuestionWeightage(BigDecimal.valueOf(qWeight != null ? qWeight : 0));
+            answer.setSectionWeightage(BigDecimal.valueOf(sWeight != null ? sWeight : 0));
+        }
+
+        // Group answers by surveyResponseUuid
+        Map<String, List<AnswerNew>> answersByResponseUuid = answers.stream()
+                .filter(a -> a.getSurveyResponseUuid() != null)
+                .collect(Collectors.groupingBy(AnswerNew::getSurveyResponseUuid));
+
+        // 3. Batch user search for all unique citizenIds in this batch
+        List<String> citizenIds = surveyResponses.stream()
+                .map(SurveyResponseNew::getCitizenId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<String, UserSearchResponseContent> userMap = new HashMap<>();
+        if (!CollectionUtils.isEmpty(citizenIds)) {
+            try {
+                userMap = userService.searchUser(requestInfo, citizenIds);
+            } catch (Exception e) {
+                log.error("Failed to search user details for plainsearch batch", e);
+            }
+        }
+
         List<ScorecardAnswerResponse> responses = new ArrayList<>();
 
-        for (String surveyUuid : surveyUuids) {
-            List<AnswerNew> answers = surveyRepository.getAnswersForSurvey(surveyUuid, criteria.getTenantId());
-            for (AnswerNew answer : answers) {
-                Integer qWeight = surveyRepository.getQuestionWeightage(answer.getQuestionUuid(), answer.getSectionUuid());
-                Integer sWeight = surveyRepository.getSectionWeightage(answer.getSectionUuid());
-                answer.setQuestionWeightage(BigDecimal.valueOf(qWeight));
-                answer.setSectionWeightage(BigDecimal.valueOf(sWeight));
+        for (SurveyResponseNew sr : surveyResponses) {
+            List<AnswerNew> responseAnswers = answersByResponseUuid.getOrDefault(sr.getUuid(), Collections.emptyList());
+
+            // Skip orphaned survey_response rows with zero answers
+            if (CollectionUtils.isEmpty(responseAnswers)) {
+                log.warn("Skipping survey response uuid={} citizenId={} — no answers found in DB", sr.getUuid(), sr.getCitizenId());
+                continue;
             }
 
-            List<SurveyResponseNew> surveyResponses = surveyRepository.getSurveyResponsesBySurveyAndTenant(surveyUuid, criteria.getTenantId());
-
-            for (SurveyResponseNew sr : surveyResponses) {
-
-                // ✅ ✅ FETCH USER DETAILS USING citizenId
-                String citizenId = sr.getCitizenId();
-                Map<String, UserSearchResponseContent> userMap = null;
-                UserSearchResponseContent user;
-
-                try {
-                    userMap = userService.searchUser(requestInfo,
-                            Collections.singletonList(citizenId));
-                    user = userMap.get(citizenId);
-                } catch (Exception e) {
-                    user = new UserSearchResponseContent();
-                    user.setUuid(citizenId);
-                }
-
-                JsonNode userNode = mapper.convertValue(user, JsonNode.class);
-
-                // ✅ ✅ ATTACH userDetails to each answerDetail
-                for (AnswerNew answer : answers) {
-                    if (answer.getAnswerDetails() != null) {
-                        answer.getAnswerDetails().forEach(detail -> detail.setUserDetails(userNode));
-                    }
-                }
-
-
-
-
-                AnswerFetchCriteria scopedCriteria = AnswerFetchCriteria.builder()
-                        .surveyUuid(surveyUuid)
-                        .citizenId(sr.getCitizenId())
-                        .tenantId(criteria.getTenantId())
-                        .build();
-
-                ScorecardAnswerResponse response = buildScorecardAnswerResponseWithWeightage(answers, scopedCriteria);
-                String surveyTitle = surveyRepository.getSurveyTitleByUuid(sr.getSurveyUuid());
-                response.setSurveyUuid(sr.getSurveyUuid());
-                response.setSurveyName(surveyTitle);
-                response.setSurveyTitle(surveyTitle);
-                response.setTenantId(sr.getTenantId());
-                response.setCitizenId(sr.getCitizenId());
-                response.setLocality(sr.getLocality());
-                response.setStatus(sr.getStatus().toString());
-                response.setCoordinates(sr.getCoordinates());
-                response.setComments(sr.getComments());
-                responses.add(response);
+            UserSearchResponseContent user = userMap.get(sr.getCitizenId());
+            if (user == null) {
+                user = new UserSearchResponseContent();
+                user.setUuid(sr.getCitizenId());
             }
+            JsonNode userNode = mapper.convertValue(user, JsonNode.class);
+
+            for (AnswerNew answer : responseAnswers) {
+                if (answer.getAnswerDetails() != null) {
+                    answer.getAnswerDetails().forEach(detail -> detail.setUserDetails(userNode));
+                }
+            }
+
+            AnswerFetchCriteria scopedCriteria = AnswerFetchCriteria.builder()
+                    .surveyUuid(sr.getSurveyUuid())
+                    .citizenId(sr.getCitizenId())
+                    .tenantId(sr.getTenantId())
+                    .build();
+
+            ScorecardAnswerResponse response = buildScorecardAnswerResponseWithWeightage(responseAnswers, scopedCriteria);
+            String surveyTitle = surveyRepository.getSurveyTitleByUuid(sr.getSurveyUuid());
+            response.setSurveyUuid(sr.getSurveyUuid());
+            response.setSurveyName(surveyTitle);
+            response.setSurveyTitle(surveyTitle);
+            response.setTenantId(sr.getTenantId());
+            response.setCitizenId(sr.getCitizenId());
+            response.setLocality(sr.getLocality());
+            response.setStatus(sr.getStatus() != null ? sr.getStatus().toString() : null);
+            response.setCoordinates(sr.getCoordinates());
+            response.setComments(sr.getComments());
+            responses.add(response);
         }
 
         PlainSearchResponse response = PlainSearchResponse.builder()
                 .surveyResponses(responses)
                 .build();
-        producer.push("csc-answer-legacyIndex", response);
+
+        // Push each survey response individually to avoid Kafka RecordTooLargeException.
+        // Batching all responses into one message can exceed max.request.size (default 1MB)
+        // when data is large. The indexer's jsonPath ($.SurveyResponses.*) handles
+        // a single-element list identically to a full batch.
+        for (ScorecardAnswerResponse individualResponse : responses) {
+            PlainSearchResponse singleItemPayload = PlainSearchResponse.builder()
+                    .surveyResponses(Collections.singletonList(individualResponse))
+                    .build();
+            try {
+                producer.push("csc-answer-legacyIndex", singleItemPayload);
+            } catch (Exception e) {
+                log.error("Failed to push legacy index for surveyUuid={} citizenId={}: {}",
+                        individualResponse.getSurveyUuid(), individualResponse.getCitizenId(), e.getMessage());
+            }
+        }
         return response;
     }
 

--- a/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/web/models/AnswerFetchCriteria.java
+++ b/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/web/models/AnswerFetchCriteria.java
@@ -26,4 +26,10 @@ public class AnswerFetchCriteria {
     @JsonProperty("tenantId")
     private String tenantId;
 
+    @JsonProperty("offset")
+    private Integer offset = 0;
+
+    @JsonProperty("limit")
+    private Integer limit = 50;
+
 }

--- a/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/web/models/AnswerNew.java
+++ b/core-services/egov-survey-services/src/main/java/org/egov/egovsurveyservices/web/models/AnswerNew.java
@@ -36,5 +36,9 @@ public class AnswerNew {
     private List<AnswerDetail> answerDetails;
     @JsonProperty("comments")
     private String comments;
+    @JsonProperty("surveyResponseUuid")
+    private String surveyResponseUuid;
+    @JsonProperty("citizenId")
+    private String citizenId;
     private AuditDetails auditDetails;
 }


### PR DESCRIPTION
This pull request introduces efficient pagination and batching to the plain search API for survey answers, addressing performance and scalability issues when handling large datasets. The changes include new paginated database queries, batch user lookups, and improved Kafka publishing logic to avoid oversized messages. Additionally, the data models and row mappers are extended to support the new workflow.

**Backend API and Query Enhancements:**

* Implemented paginated fetching of survey responses in `ScorecardSurveyRepository` via the new `getSurveyResponsesByTenantPaginated` method, and added a batch query for answers with `getAnswersForSurveyResponses`.
* Updated the service layer (`ScorecardSurveyService`) to use the paginated queries, batch fetch user details for all relevant citizen IDs, and group answers by survey response UUID for efficient processing.

**Kafka Publishing Improvements:**

* Changed legacy index publishing to push each survey response individually instead of batching, preventing Kafka `RecordTooLargeException` when handling large payloads.

**Model and Row Mapper Updates:**

* Extended `AnswerNew` and `AnswerRowMapper` to include `surveyResponseUuid` and `citizenId`, ensuring these fields are available for grouping and user lookup. [[1]](diffhunk://#diff-85296159b5a99be4ae25f88a9edc48a1fd4d7a59a39b02a53d17b8d6893f95a7R39-R42) [[2]](diffhunk://#diff-b9df56ed01bfd2e46162ec2a45ee77246947eeefb4f328fe78db49a4b137ef9dR54-R67)
* Added `offset` and `limit` fields to `AnswerFetchCriteria` to support pagination parameters in API requests.