### PR TITLE
Disable adding applicant mobile to notification recipients

### DIFF
--- a/municipal-services/sw-services/src/main/java/org/egov/swservice/service/WorkflowNotificationService.java
+++ b/municipal-services/sw-services/src/main/java/org/egov/swservice/service/WorkflowNotificationService.java
@@ -504,12 +504,12 @@ public class WorkflowNotificationService {
 		}
 
 		//Send the notification to applicant
-		if(!StringUtils.isEmpty(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber()))
-		{
-			mobileNumbersAndNames.put(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), sewerageConnectionRequest.getRequestInfo().getUserInfo().getName());
-			mobileNumbers.add(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber());
-			mobileNumberAndEmailId.put(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), sewerageConnectionRequest.getRequestInfo().getUserInfo().getEmailId());
-		}
+		// if(!StringUtils.isEmpty(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber()))
+		// {
+		// 	mobileNumbersAndNames.put(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), sewerageConnectionRequest.getRequestInfo().getUserInfo().getName());
+		// 	mobileNumbers.add(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber());
+		// 	mobileNumberAndEmailId.put(sewerageConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), sewerageConnectionRequest.getRequestInfo().getUserInfo().getEmailId());
+		// }
 
 		Map<String, String> mobileNumberAndMessage = getMessageForMobileNumber(mobileNumbersAndNames,
 				sewerageConnectionRequest, message, property);

--- a/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WorkflowNotificationService.java
+++ b/municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WorkflowNotificationService.java
@@ -489,12 +489,12 @@ public class WorkflowNotificationService {
         }
 
         //Send the notification to applicant
-        if(!StringUtils.isEmpty(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber()))
-        {
-            mobileNumbersAndNames.put(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), waterConnectionRequest.getRequestInfo().getUserInfo().getName());
-            mobileNumbers.add(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber());
-            mobileNumberAndEmailId.put(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), waterConnectionRequest.getRequestInfo().getUserInfo().getEmailId());
-        }
+        // if(!StringUtils.isEmpty(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber()))
+        // {
+        //     mobileNumbersAndNames.put(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), waterConnectionRequest.getRequestInfo().getUserInfo().getName());
+        //     mobileNumbers.add(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber());
+        //     mobileNumberAndEmailId.put(waterConnectionRequest.getRequestInfo().getUserInfo().getMobileNumber(), waterConnectionRequest.getRequestInfo().getUserInfo().getEmailId());
+        // }
 
         if (message != null) {
         	Map<String, String> mobileNumberAndMessage = getMessageForMobileNumber(mobileNumbersAndNames,


### PR DESCRIPTION
Comment out the blocks that add the applicant's mobile number, name and email to the notification recipient collections in WorkflowNotificationService for both sewerage and water services. This prevents the applicant from being added to mobileNumbersAndNames, mobileNumbers and mobileNumberAndEmailId while leaving the rest of the notification flow unchanged. Modified files:
- municipal-services/sw-services/src/main/java/org/egov/swservice/service/WorkflowNotificationService.java
- municipal-services/ws-services/src/main/java/org/egov/waterconnection/service/WorkflowNotificationService.java