### PR TITLE
Update DGR application title metadata

### DIFF
--- a/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/consumer/DgrIntegration.java
+++ b/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/consumer/DgrIntegration.java
@@ -423,15 +423,19 @@ public class DgrIntegration {
                             ? catSubCat.get("Sub_Category_ID").toString()
                             : "0");
 
-            requestBody.put(
+            String applicationTitle = safeValue(
+            	    constants.DEFAULT_DESCRIPTION_NAME,
+            	    serviceReqRequest.getServices().get(0).getDescription()
+            	);
+
+            	requestBody.put(
             	    "Application_Title",
-            	    safeValue(constants.DEFAULT_CITIZEN_NAME,
-            	              serviceReqRequest.getServices().get(0).getDescription())
+            	    applicationTitle + " - " + serviceReqRequest.getServices().get(0).getServiceRequestId()
             	);
 
             	requestBody.put(
             	    "Application_Description",
-            	    safeValue(constants.DEFAULT_CITIZEN_NAME,
+            	    safeValue(constants.DEFAULT_DESCRIPTION_NAME,
             	              serviceReqRequest.getServices().get(0).getDescription())
             	);
             	requestBody.put("Application_Department_Name",   Optional.ofNullable(catSubCat.get("Department_Name"))

--- a/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/utils/PGRConstants.java
+++ b/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/utils/PGRConstants.java
@@ -123,6 +123,8 @@ public class PGRConstants {
 	    // =========================
 	    // Citizen defaults
 	    // =========================
+    	public static final String DEFAULT_DESCRIPTION_NAME = "No Description/Title(Subject) Is Provided By User in PMIDC";
+
 	    public static final String DEFAULT_CITIZEN_NAME = "No Name Is Provided By User in PMIDC";
 	    public static final String DEFAULT_CITIZEN_EMAIL = "temp@example.com";
 	    public static final String DEFAULT_CITIZEN_MOBILE = "0000000000";


### PR DESCRIPTION
This change adds a default fallback description/title constant for missing PGR input and updates the DGR integration payload to set Application_Title as the description plus the service request ID. It also keeps Application_Description using the same default fallback so submissions remain consistent when users do not provide a title or description.