### PR TITLE
Fix PGR application title formatting

### DIFF
--- a/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/consumer/DgrIntegration.java
+++ b/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/consumer/DgrIntegration.java
@@ -423,15 +423,19 @@ public class DgrIntegration {
                             ? catSubCat.get("Sub_Category_ID").toString()
                             : "0");
 
-            requestBody.put(
+            String applicationTitle = safeValue(
+            	    constants.DEFAULT_DESCRIPTION_NAME,
+            	    serviceReqRequest.getServices().get(0).getDescription()
+            	);
+
+            	requestBody.put(
             	    "Application_Title",
-            	    safeValue(constants.DEFAULT_CITIZEN_NAME,
-            	              serviceReqRequest.getServices().get(0).getDescription())
+            	    applicationTitle + " - " + serviceReqRequest.getServices().get(0).getServiceRequestId()
             	);
 
             	requestBody.put(
             	    "Application_Description",
-            	    safeValue(constants.DEFAULT_CITIZEN_NAME,
+            	    safeValue(constants.DEFAULT_DESCRIPTION_NAME,
             	              serviceReqRequest.getServices().get(0).getDescription())
             	);
             	requestBody.put("Application_Department_Name",   Optional.ofNullable(catSubCat.get("Department_Name"))

--- a/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/utils/PGRConstants.java
+++ b/municipal-services/rainmaker-pgr/src/main/java/org/egov/pgr/utils/PGRConstants.java
@@ -123,6 +123,8 @@ public class PGRConstants {
 	    // =========================
 	    // Citizen defaults
 	    // =========================
+    	public static final String DEFAULT_DESCRIPTION_NAME = "No Description/Title(Subject) Is Provided By User in PMIDC";
+
 	    public static final String DEFAULT_CITIZEN_NAME = "No Name Is Provided By User in PMIDC";
 	    public static final String DEFAULT_CITIZEN_EMAIL = "temp@example.com";
 	    public static final String DEFAULT_CITIZEN_MOBILE = "0000000000";


### PR DESCRIPTION
Update DGR integration to use a dedicated default description constant and append the service request ID to the external application title. This prevents blank or misleading titles when a complaint description is missing and makes the title unique and more informative for downstream processing.